### PR TITLE
-- clean-up rework-rate and revert-rate documents in kpi_master collection -- remove dublicate document for kpi-201

### DIFF
--- a/src/main/resources/json/mongock/default/kpi_master.json
+++ b/src/main/resources/json/mongock/default/kpi_master.json
@@ -4442,52 +4442,6 @@
     ]
   },
   {
-    "kpiId": "kpi173",
-    "kpiName": "Rework Rate",
-    "maxValue": "",
-    "kpiUnit": "%",
-    "isDeleted": true,
-    "defaultOrder": 5,
-    "groupId": 7,
-    "kpiSource": "BitBucket",
-    "combinedKpiSource": "Bitbucket/AzureRepository/GitHub/GitLab",
-    "kanban": false,
-    "chartType": "line",
-    "kpiInfo": {
-      "definition": "Percentage of code changes in which an engineer rewrites code that they recently updated (within the past three weeks).",
-      "details": [
-        {
-          "type": "link",
-          "kpiLinkDetail": {
-            "text": "Detailed Information at",
-            "link": "https://knowhow.tools.publicis.sapient.com/wiki/kpi173-Rework+Rate"
-          }
-        }
-      ]
-    },
-    "upperThresholdBG": "red",
-    "lowerThresholdBG": "white",
-    "thresholdValue": "50",
-    "xAxisLabel": "Weeks",
-    "yAxisLabel": "Percentage",
-    "isPositiveTrend": false,
-    "showTrend": true,
-    "kpiFilter": "dropDown",
-    "aggregationCriteria": "average",
-    "isAdditionalFilterSupport": false,
-    "calculateMaturity": false,
-    "hideOverallFilter": true,
-    "isRepoToolKpi": true,
-    "kpiCategory": "Developer",
-    "maturityRange": [
-      "-80",
-      "80-50",
-      "50-20",
-      "20-5",
-      "5-"
-    ]
-  },
-  {
     "kpiId": "kpi176",
     "kpiName": "Risks And Dependencies",
     "maxValue": "",
@@ -4661,52 +4615,6 @@
     "hideOverallFilter": true,
     "isRepoToolKpi": true,
     "kpiCategory": "Developer"
-  },
-  {
-    "kpiId": "kpi180",
-    "kpiName": "Revert Rate",
-    "maxValue": "",
-    "kpiUnit": "%",
-    "isDeleted": true,
-    "defaultOrder": 5,
-    "groupId": 7,
-    "kpiSource": "BitBucket",
-    "combinedKpiSource": "Bitbucket/AzureRepository/GitHub/GitLab",
-    "kanban": false,
-    "chartType": "line",
-    "kpiInfo": {
-      "definition": "The percentage of total pull requests opened that are reverts.",
-      "details": [
-        {
-          "type": "link",
-          "kpiLinkDetail": {
-            "text": "Detailed Information at",
-            "link": "https://knowhow.tools.publicis.sapient.com/wiki/kpi180-Revert+Rate"
-          }
-        }
-      ]
-    },
-    "upperThresholdBG": "red",
-    "lowerThresholdBG": "white",
-    "thresholdValue": "50",
-    "xAxisLabel": "Weeks",
-    "yAxisLabel": "Percentage",
-    "isPositiveTrend": false,
-    "showTrend": true,
-    "kpiFilter": "dropDown",
-    "aggregationCriteria": "average",
-    "isAdditionalFilterSupport": false,
-    "calculateMaturity": false,
-    "hideOverallFilter": true,
-    "isRepoToolKpi": true,
-    "kpiCategory": "Developer",
-    "maturityRange": [
-      "-80",
-      "80-50",
-      "50-20",
-      "20-5",
-      "5-"
-    ]
   },
   {
     "kpiId": "kpi182",
@@ -5300,55 +5208,6 @@
     "isDeleted": "False",
     "kpiName": "Sprint Analytics",
     "kpiSource": "Jira"
-  },
-  {
-    "kpiUnit" : "%",
-    "aggregationCriteria" : "average",
-    "kpiCategory" : "Developer",
-    "maxValue" : "",
-    "kpiFilter" : "dropDown",
-    "kpiId" : "kpi201",
-    "groupId" : 2,
-    "kpiName" : "Code Quality Metrics",
-    "isAdditionalFilterSupport" : false,
-    "calculateMaturity" : false,
-    "hideOverallFilter" : true,
-    "isRepoToolKpi" : true,
-    "combinedKpiSource" : "Bitbucket/AzureRepository/GitHub/GitLab",
-    "showTrend" : true,
-    "isDeleted" : false,
-    "defaultOrder" : 7,
-    "kpiInfo" : {
-      "definition" : "Code Quality Metrics - a combination of revert rate and rework rate percentage values",
-      "details" : [
-        {
-          "text" : "Revert Rate: The percentage of total pull requests opened that are reverts.",
-          "type" : "paragraph"
-        },
-        {
-          "type" : "link",
-          "kpiLinkDetail" : {
-            "link" : "https://knowhow.tools.publicis.sapient.com/wiki/kpi180-Revert+Rate",
-            "text" : "Revert Rate - Detailed Information at"
-          }
-        },
-        {
-          "text" : "Rework Rate: Percentage of code changes in which an engineer rewrites code that they recently updated (within the past three weeks).",
-          "type" : "paragraph"
-        },
-        {
-          "type" : "link",
-          "kpiLinkDetail" : {
-            "link" : "https://knowhow.tools.publicis.sapient.com/wiki/kpi173-Rework+Rate",
-            "text" : "Rework Rate - Detailed Information at"
-          }
-        }
-      ]
-    },
-    "kanban" : false,
-    "chartType" : "progressbar",
-    "isPositiveTrend" : false,
-    "kpiSource" : "BitBucket"
   },
   {
     "kpiId" : "kpi201",

--- a/src/test/java/com/publicissapient/kpidashboard/apis/bitbucket/service/RevertRateServiceImplTest.java
+++ b/src/test/java/com/publicissapient/kpidashboard/apis/bitbucket/service/RevertRateServiceImplTest.java
@@ -37,6 +37,7 @@ import java.util.Set;
 
 import org.bson.types.ObjectId;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
@@ -73,6 +74,7 @@ import com.publicissapient.kpidashboard.common.model.jira.AssigneeDetails;
 import com.publicissapient.kpidashboard.common.service.AssigneeDetailsServiceImpl;
 
 @RunWith(MockitoJUnitRunner.class)
+@Ignore("Skipping test cases since it Removed due KPI outdated")
 public class RevertRateServiceImplTest {
 
 	private static final String OVERALL = "Overall";


### PR DESCRIPTION
**This PR addresses two issues:**

**UI Cleanup:** Removes obsolete Rework (kpi173) and Revert Rate (kpi180) KPIs that are no longer needed to display on the UI

**Duplicate Key Fix**: Resolves application startup failure caused by duplicate kpi201 documents