### PR TITLE
Fix API Documentation URL Construction

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -543,7 +543,7 @@ executive.dashboard.timeout.minutes=3
 
 ## Help & Support Configuration - Start
 help.productDocumentationUrl=https://knowhow.suite.publicissapient.com/wiki/spaces/PS/pages/42631197/KnowHOW+-+Product+Guide
-help.apiDocumentationUrl=https://knowhow.tools.publicis.sapient.com/api/swagger-ui/index.html
+help.apiDocumentationUrl=/api/swagger-ui/index.html
 help.videoTutorialsUrl=https://videos.example.com/tutorials
 help.raiseTicketUrl=https://publicissapient.atlassian.net/servicedesk/customer/portal/7/group/48/create/101
 help.supportChannelUrl=https://teams.microsoft.com/l/channel/19%3A251941efc821483d8e92c0b80b59035e%40thread.tacv2/D.%20KnowHOW%20(KPI%20dashboard)?groupId=34fe3d0b-9154-4ee6-90fa-10e1a3efdff8&tenantId=d52c9ea1-7c21-47b1-82a3-33a74b1f74b8


### PR DESCRIPTION
passing only /swagger-ui/index.html instead of prod url