### PR TITLE
Fixing demo comments/issues

### DIFF
--- a/src/main/java/com/publicissapient/kpidashboard/apis/appsetting/service/KPIExcelDataService.java
+++ b/src/main/java/com/publicissapient/kpidashboard/apis/appsetting/service/KPIExcelDataService.java
@@ -406,11 +406,17 @@ public class KPIExcelDataService {
 			kpiColumnConfigDTO =
 					kpiColumnConfigService.getByKpiColumnConfig(
 							projectBasicConfigID, totalKpiElementList.get(0).getKpiId());
+			if (kpiColumnConfigDTO == null) {
+				kpiColumnConfigDTO = new KpiColumnConfigDTO();
+			}
 			kpiColumnConfigDTO.setSaveFlag(true);
 
 		} else {
 			kpiColumnConfigDTO =
 					kpiColumnConfigService.getByKpiColumnConfig(null, totalKpiElementList.get(0).getKpiId());
+			if (kpiColumnConfigDTO == null) {
+				kpiColumnConfigDTO = new KpiColumnConfigDTO();
+			}
 			kpiColumnConfigDTO.setSaveFlag(false);
 		}
 		prepareKpiExcelValidationDataResponse(
@@ -667,6 +673,7 @@ public class KPIExcelDataService {
 					String kpiId = pair.getValue().getKpiList().get(0).getKpiId();
 					if (category.contains(pair.getValue().getKpiList().get(0).getKpiCategory())
 							|| kpiId.equalsIgnoreCase("kpi148")
+							|| kpiId.equalsIgnoreCase("kpi206")
 							|| kpiId.equalsIgnoreCase("kpi207")) {
 						// when request coming from ITERATION/RELEASE/BACKLOG board
 						if (Boolean.TRUE.equals(apiAuth)) {

--- a/src/main/java/com/publicissapient/kpidashboard/apis/config/CustomApiConfig.java
+++ b/src/main/java/com/publicissapient/kpidashboard/apis/config/CustomApiConfig.java
@@ -351,6 +351,11 @@ public class CustomApiConfig { // NOPMD
 	@Setter
 	private int slingShotFlowKpiMonthCount;
 
+	@Value("${flowDistributionIncludeHistoricalData:false}")
+	@Getter
+	@Setter
+	private boolean flowDistributionIncludeHistoricalData;
+
 	public String getDefectRateUrl() {
 		return defectRateUrl;
 	}

--- a/src/main/java/com/publicissapient/kpidashboard/apis/config/CustomApiConfig.java
+++ b/src/main/java/com/publicissapient/kpidashboard/apis/config/CustomApiConfig.java
@@ -356,6 +356,11 @@ public class CustomApiConfig { // NOPMD
 	@Setter
 	private boolean flowDistributionIncludeHistoricalData;
 
+	@Value("${slingshotSprintVelocityMultiGranularity:false}")
+	@Getter
+	@Setter
+	private boolean slingshotSprintVelocityMultiGranularity;
+
 	public String getDefectRateUrl() {
 		return defectRateUrl;
 	}

--- a/src/main/java/com/publicissapient/kpidashboard/apis/config/CustomApiConfig.java
+++ b/src/main/java/com/publicissapient/kpidashboard/apis/config/CustomApiConfig.java
@@ -347,7 +347,9 @@ public class CustomApiConfig { // NOPMD
 	private int executiveTimeoutMinutes;
 
 	@Value("${slingShotFlowKpiMonthCount:3}")
-	@Getter @Setter private int slingShotFlowKpiMonthCount;
+	@Getter
+	@Setter
+	private int slingShotFlowKpiMonthCount;
 
 	public String getDefectRateUrl() {
 		return defectRateUrl;

--- a/src/main/java/com/publicissapient/kpidashboard/apis/config/CustomApiConfig.java
+++ b/src/main/java/com/publicissapient/kpidashboard/apis/config/CustomApiConfig.java
@@ -346,6 +346,7 @@ public class CustomApiConfig { // NOPMD
 	@Value("${executive.dashboard.timeout.minutes:3}")
 	private int executiveTimeoutMinutes;
 
+	@Value("${slingShotFlowKpiMonthCount:3}")
 	@Getter @Setter private int slingShotFlowKpiMonthCount;
 
 	public String getDefectRateUrl() {

--- a/src/main/java/com/publicissapient/kpidashboard/apis/jira/scrum/service/FlowDistributionServiceImpl.java
+++ b/src/main/java/com/publicissapient/kpidashboard/apis/jira/scrum/service/FlowDistributionServiceImpl.java
@@ -159,17 +159,33 @@ public class FlowDistributionServiceImpl extends JiraBacklogKPIService<Double, L
 													issue -> combineType(issue.getStoryType()),
 													Collectors.summingInt(issue -> 1))));
 
+			Map<String, Map<String, List<String>>> groupByDateAndTypeIds =
+					jiraIssueCustomHistories.stream()
+							.collect(
+									Collectors.groupingBy(
+											issue ->
+													DateUtil.convertJodaDateTimeToLocalDateTime(issue.getCreatedDate())
+															.toLocalDate()
+															.toString(),
+											Collectors.groupingBy(
+													issue -> combineType(issue.getStoryType()),
+													Collectors.mapping(
+															JiraIssueCustomHistory::getStoryID, Collectors.toList()))));
+
 			// Sort the groupByDateAndTypeCount map by date in ascending order
 			TreeMap<String, Map<String, Integer>> sortedByDateTypeCountMap =
 					new TreeMap<>(groupByDateAndTypeCount);
 
-			// Get the map from the start date or the immediate next date for modal window
-			Map<String, Map<String, Integer>> mapAfterStartDate =
-					sortedByDateTypeCountMap.entrySet().stream()
+			TreeMap<String, Map<String, List<String>>> sortedByDateTypeIdsMap =
+					new TreeMap<>(groupByDateAndTypeIds);
+
+			// Get the map from the start date or the immediate next date for explore table
+			Map<String, Map<String, List<String>>> mapAfterStartDateIds =
+					sortedByDateTypeIdsMap.entrySet().stream()
 							.filter(entry -> entry.getKey().compareTo(startDate) >= 0)
 							.findFirst()
 							.map(Map.Entry::getKey)
-							.map(sortedByDateTypeCountMap::tailMap)
+							.map(sortedByDateTypeIdsMap::tailMap)
 							.orElse(new TreeMap<>());
 
 			// fetching the start date backlog type count
@@ -183,7 +199,7 @@ public class FlowDistributionServiceImpl extends JiraBacklogKPIService<Double, L
 					createCumulativeTypeCount(startDate, endDate, sortedByDateTypeCountMap);
 
 			populateTrendValueList(trendValueList, cumulativeAddedCountMap);
-			populateExcelDataObject(requestTrackerId, excelData, mapAfterStartDate);
+			populateExcelDataObject(requestTrackerId, excelData, mapAfterStartDateIds);
 			log.info(
 					"FlowDistributionServiceImpl -> request id : {} dateWiseCountMap : {}",
 					requestTrackerId,
@@ -219,15 +235,15 @@ public class FlowDistributionServiceImpl extends JiraBacklogKPIService<Double, L
 	 *
 	 * @param requestTrackerId
 	 * @param excelData
-	 * @param dateTypeCountMap
+	 * @param dateTypeIdsMap
 	 */
 	private void populateExcelDataObject(
 			String requestTrackerId,
 			List<KPIExcelData> excelData,
-			Map<String, Map<String, Integer>> dateTypeCountMap) {
+			Map<String, Map<String, List<String>>> dateTypeIdsMap) {
 		if (requestTrackerId.toLowerCase().contains(KPISource.EXCEL.name().toLowerCase())
-				&& !Objects.isNull(dateTypeCountMap)) {
-			KPIExcelUtility.populateFlowKPI(dateTypeCountMap, excelData);
+				&& !Objects.isNull(dateTypeIdsMap)) {
+			KPIExcelUtility.populateFlowKPIWithIds(dateTypeIdsMap, excelData);
 		}
 	}
 

--- a/src/main/java/com/publicissapient/kpidashboard/apis/jira/scrum/service/slingshot/FlowDistributionSlingshotServiceImpl.java
+++ b/src/main/java/com/publicissapient/kpidashboard/apis/jira/scrum/service/slingshot/FlowDistributionSlingshotServiceImpl.java
@@ -123,7 +123,7 @@ public class FlowDistributionSlingshotServiceImpl
 
 		// this method fetch dates for past history data
 		CustomDateRange dateRange =
-				KpiDataHelper.getMonthsForPastDataHistory(customApiConfig.getFlowKpiMonthCount());
+				KpiDataHelper.getMonthsForPastDataHistory(customApiConfig.getSlingShotFlowKpiMonthCount());
 
 		// get start and end date in yyyy-mm-dd format
 		String startDate = dateRange.getStartDate().format(DATE_FORMATTER);

--- a/src/main/java/com/publicissapient/kpidashboard/apis/jira/scrum/service/slingshot/FlowDistributionSlingshotServiceImpl.java
+++ b/src/main/java/com/publicissapient/kpidashboard/apis/jira/scrum/service/slingshot/FlowDistributionSlingshotServiceImpl.java
@@ -155,17 +155,31 @@ public class FlowDistributionSlingshotServiceImpl
 													issue -> combineType(issue.getStoryType()),
 													Collectors.summingInt(issue -> 1))));
 
+			Map<String, Map<String, List<String>>> groupByDateAndTypeIds =
+					jiraIssueCustomHistories.stream()
+							.filter(issue -> getClosedDate(issue, closedStatuses) != null)
+							.collect(
+									Collectors.groupingBy(
+											issue -> getClosedDate(issue, closedStatuses).toLocalDate().toString(),
+											Collectors.groupingBy(
+													issue -> combineType(issue.getStoryType()),
+													Collectors.mapping(
+															JiraIssueCustomHistory::getStoryID, Collectors.toList()))));
+
 			// Sort the groupByDateAndTypeCount map by date in ascending order
 			TreeMap<String, Map<String, Integer>> sortedByDateTypeCountMap =
 					new TreeMap<>(groupByDateAndTypeCount);
 
-			// Get the map from the start date or the immediate next date for modal window
-			Map<String, Map<String, Integer>> mapAfterStartDate =
-					sortedByDateTypeCountMap.entrySet().stream()
+			TreeMap<String, Map<String, List<String>>> sortedByDateTypeIdsMap =
+					new TreeMap<>(groupByDateAndTypeIds);
+
+			// Get the map from the start date or the immediate next date for explore table
+			Map<String, Map<String, List<String>>> mapAfterStartDateIds =
+					sortedByDateTypeIdsMap.entrySet().stream()
 							.filter(entry -> entry.getKey().compareTo(startDate) >= 0)
 							.findFirst()
 							.map(Map.Entry::getKey)
-							.map(sortedByDateTypeCountMap::tailMap)
+							.map(sortedByDateTypeIdsMap::tailMap)
 							.orElse(new TreeMap<>());
 
 			if (customApiConfig.isFlowDistributionIncludeHistoricalData()) {
@@ -181,7 +195,7 @@ public class FlowDistributionSlingshotServiceImpl
 					createCumulativeTypeCount(startDate, endDate, sortedByDateTypeCountMap);
 
 			populateTrendValueList(trendValueList, cumulativeAddedCountMap);
-			populateExcelDataObject(requestTrackerId, excelData, mapAfterStartDate);
+			populateExcelDataObject(requestTrackerId, excelData, mapAfterStartDateIds);
 			log.info(
 					"FlowDistributionServiceImpl -> request id : {} dateWiseCountMap : {}",
 					requestTrackerId,
@@ -217,15 +231,15 @@ public class FlowDistributionSlingshotServiceImpl
 	 *
 	 * @param requestTrackerId
 	 * @param excelData
-	 * @param dateTypeCountMap
+	 * @param dateTypeIdsMap
 	 */
 	private void populateExcelDataObject(
 			String requestTrackerId,
 			List<KPIExcelData> excelData,
-			Map<String, Map<String, Integer>> dateTypeCountMap) {
+			Map<String, Map<String, List<String>>> dateTypeIdsMap) {
 		if (requestTrackerId.toLowerCase().contains(KPISource.EXCEL.name().toLowerCase())
-				&& !Objects.isNull(dateTypeCountMap)) {
-			KPIExcelUtility.populateFlowKPI(dateTypeCountMap, excelData);
+				&& !Objects.isNull(dateTypeIdsMap)) {
+			KPIExcelUtility.populateFlowKPIWithIds(dateTypeIdsMap, excelData);
 		}
 	}
 

--- a/src/main/java/com/publicissapient/kpidashboard/apis/jira/scrum/service/slingshot/FlowDistributionSlingshotServiceImpl.java
+++ b/src/main/java/com/publicissapient/kpidashboard/apis/jira/scrum/service/slingshot/FlowDistributionSlingshotServiceImpl.java
@@ -168,12 +168,14 @@ public class FlowDistributionSlingshotServiceImpl
 							.map(sortedByDateTypeCountMap::tailMap)
 							.orElse(new TreeMap<>());
 
-			// fetching the start date backlog type count
-			Map<String, Integer> startDateTypeCount =
-					startDateTypeCount(startDate, sortedByDateTypeCountMap);
+			if (customApiConfig.isFlowDistributionIncludeHistoricalData()) {
+				// fetching the start date backlog type count
+				Map<String, Integer> startDateTypeCount =
+						startDateTypeCount(startDate, sortedByDateTypeCountMap);
 
-			// adding start date backlog count for cumulativeAddition
-			addStartDateTypeCount(startDate, sortedByDateTypeCountMap, startDateTypeCount);
+				// adding start date backlog count for cumulativeAddition
+				addStartDateTypeCount(startDate, sortedByDateTypeCountMap, startDateTypeCount);
+			}
 
 			Map<String, Map<String, Integer>> cumulativeAddedCountMap =
 					createCumulativeTypeCount(startDate, endDate, sortedByDateTypeCountMap);

--- a/src/main/java/com/publicissapient/kpidashboard/apis/jira/scrum/service/slingshot/FlowLoadSlingshotServiceImpl.java
+++ b/src/main/java/com/publicissapient/kpidashboard/apis/jira/scrum/service/slingshot/FlowLoadSlingshotServiceImpl.java
@@ -173,7 +173,9 @@ public class FlowLoadSlingshotServiceImpl extends JiraBacklogKPIService<Double, 
 
 		if (MapUtils.isNotEmpty(dateWithStatusCount)) {
 			populateTrendValueList(trendValueList, dateWithStatusCount);
-			populateExcelDataObject(requestTrackerId, excelData, dateWithStatusCount);
+			Map<String, Map<String, List<String>>> dateStatusIdsMap =
+					buildDateStatusIdsMap(jiraIssueCustomHistories, startDate, endDate, fieldMapping);
+			populateExcelDataObject(requestTrackerId, excelData, dateStatusIdsMap);
 			log.debug(
 					"FlowLoadServiceImpl -> request id : {} dateWithStatusCount : {}",
 					requestTrackerId,
@@ -182,6 +184,114 @@ public class FlowLoadSlingshotServiceImpl extends JiraBacklogKPIService<Double, 
 		kpiElement.setExcelData(excelData);
 		kpiElement.setExcelColumns(KPIExcelColumn.FLOW_LOAD_SLINGSHOT.getColumns());
 		kpiElement.setTrendValueList(trendValueList);
+	}
+
+	private Map<String, Map<String, List<String>>> buildDateStatusIdsMap(
+			List<JiraIssueCustomHistory> jiraIssueCustomHistories,
+			LocalDate startDate,
+			LocalDate endDate,
+			FieldMapping fieldMapping) {
+
+		Map<String, Map<String, List<String>>> dateStatusIdsMap = new HashMap<>();
+		LocalDate current = startDate;
+		while (!current.isAfter(endDate)) {
+			dateStatusIdsMap.put(current.toString(), new HashMap<>());
+			current = current.plusDays(1);
+		}
+
+		if (CollectionUtils.isNotEmpty(jiraIssueCustomHistories)) {
+			for (JiraIssueCustomHistory issue : jiraIssueCustomHistories) {
+				List<JiraHistoryChangeLog> statusChangeLog = issue.getStatusUpdationLog();
+				int size = statusChangeLog.size();
+				if (size == 0) continue;
+				String storyID = issue.getStoryID();
+
+				List<Pair<String, Pair<LocalDate, LocalDate>>> ranges =
+						extractStatusRanges(issue, statusChangeLog, size, startDate, endDate, fieldMapping);
+
+				for (Pair<String, Pair<LocalDate, LocalDate>> range : ranges) {
+					String status = range.getKey();
+					LocalDate rangeStart = range.getValue().getKey();
+					LocalDate rangeEnd = range.getValue().getValue();
+					LocalDate day = rangeStart;
+					while (!day.isAfter(rangeEnd)) {
+						Map<String, List<String>> statusIds = dateStatusIdsMap.get(day.toString());
+						if (statusIds != null) {
+							statusIds.computeIfAbsent(status, k -> new ArrayList<>()).add(storyID);
+						}
+						day = day.plusDays(1);
+					}
+				}
+			}
+		}
+
+		dateStatusIdsMap.entrySet().removeIf(e -> e.getValue().isEmpty());
+		return dateStatusIdsMap;
+	}
+
+	private List<Pair<String, Pair<LocalDate, LocalDate>>> extractStatusRanges(
+			JiraIssueCustomHistory issue,
+			List<JiraHistoryChangeLog> statusChangeLog,
+			int size,
+			LocalDate startDate,
+			LocalDate endDate,
+			FieldMapping fieldMapping) {
+
+		List<Pair<String, Pair<LocalDate, LocalDate>>> ranges = new ArrayList<>();
+
+		if (statusChangeLog.get(size - 1).getUpdatedOn().toLocalDate().isBefore(startDate)) {
+			addRangeIfValid(
+					ranges,
+					fieldMapping,
+					statusChangeLog.get(size - 1).getChangedTo(),
+					startDate,
+					endDate,
+					startDate,
+					endDate);
+		} else if (!DateUtil.convertJodaDateTimeToLocalDateTime(issue.getCreatedDate())
+				.toLocalDate()
+				.isAfter(endDate)) {
+			for (int i = 0; i + 1 < size; i++) {
+				JiraHistoryChangeLog changeLog = statusChangeLog.get(i);
+				JiraHistoryChangeLog nextChangeLog = statusChangeLog.get(i + 1);
+				addRangeIfValid(
+						ranges,
+						fieldMapping,
+						changeLog.getChangedTo(),
+						startDate,
+						endDate,
+						changeLog.getUpdatedOn().toLocalDate(),
+						nextChangeLog.getUpdatedOn().toLocalDate());
+			}
+			JiraHistoryChangeLog lastLog = statusChangeLog.get(size - 1);
+			LocalDate intervalStart = lastLog.getUpdatedOn().toLocalDate();
+			if (!intervalStart.isAfter(endDate)) {
+				addRangeIfValid(
+						ranges,
+						fieldMapping,
+						lastLog.getChangedTo(),
+						startDate,
+						endDate,
+						intervalStart,
+						endDate);
+			}
+		}
+		return ranges;
+	}
+
+	private void addRangeIfValid(
+			List<Pair<String, Pair<LocalDate, LocalDate>>> ranges,
+			FieldMapping fieldMapping,
+			String status,
+			LocalDate startDate,
+			LocalDate endDate,
+			LocalDate intervalStart,
+			LocalDate intervalEnd) {
+		if (!isStatusValid(fieldMapping, status)) return;
+		if (intervalEnd.isBefore(startDate) || intervalStart.isAfter(endDate)) return;
+		if (intervalStart.isBefore(startDate)) intervalStart = startDate;
+		if (intervalEnd.isAfter(endDate)) intervalEnd = endDate;
+		ranges.add(Pair.of(status.replace(" ", "-"), Pair.of(intervalStart, intervalEnd)));
 	}
 
 	private void calculateStatusCountForEachDay(
@@ -343,10 +453,10 @@ public class FlowLoadSlingshotServiceImpl extends JiraBacklogKPIService<Double, 
 	private void populateExcelDataObject(
 			String requestTrackerId,
 			List<KPIExcelData> excelData,
-			Map<String, Map<String, Integer>> dateWithStatusCount) {
+			Map<String, Map<String, List<String>>> dateStatusIdsMap) {
 		if (requestTrackerId.toLowerCase().contains(KPISource.EXCEL.name().toLowerCase())
-				&& !Objects.isNull(dateWithStatusCount)) {
-			KPIExcelUtility.populateFlowKPI(dateWithStatusCount, excelData);
+				&& !Objects.isNull(dateStatusIdsMap)) {
+			KPIExcelUtility.populateFlowKPIWithIds(dateStatusIdsMap, excelData);
 		}
 	}
 }

--- a/src/main/java/com/publicissapient/kpidashboard/apis/jira/scrum/service/slingshot/FlowLoadSlingshotServiceImpl.java
+++ b/src/main/java/com/publicissapient/kpidashboard/apis/jira/scrum/service/slingshot/FlowLoadSlingshotServiceImpl.java
@@ -71,9 +71,17 @@ public class FlowLoadSlingshotServiceImpl extends JiraBacklogKPIService<Double, 
 				issuesHistory = getJiraIssuesCustomHistoryFromBaseClass();
 				issuesHistory =
 						issuesHistory.stream()
-								.filter(jiraIssue -> issueTypes.contains(jiraIssue.getStoryType().toLowerCase()))
+								.filter(
+										jiraIssue ->
+												jiraIssue.getStoryType() != null
+														&& issueTypes.contains(jiraIssue.getStoryType().toLowerCase()))
 								.toList();
 			}
+
+			log.info(
+					"Flow Load Slingshot (kpi206) -> issues fetched: {} for project: {}",
+					issuesHistory != null ? issuesHistory.size() : 0,
+					leafNode.getProjectFilter().getName());
 
 			resultListMap.put(ISSUE_HISTORY, issuesHistory);
 		}
@@ -111,16 +119,28 @@ public class FlowLoadSlingshotServiceImpl extends JiraBacklogKPIService<Double, 
 				configHelperService
 						.getFieldMappingMap()
 						.get(leafNode.getProjectFilter().getBasicProjectConfigId());
+
+		if (org.apache.commons.lang3.StringUtils.isEmpty(fieldMapping.getStoryFirstStatusKPI206())
+				&& CollectionUtils.isEmpty(fieldMapping.getJiraStatusForInProgressKPI206())) {
+			log.warn(
+					"Flow Load Slingshot (kpi206): storyFirstStatusKPI206 and jiraStatusForInProgressKPI206 are not configured"
+							+ " in field mapping for project {}. Only QA statuses {} will be tracked.",
+					leafNode.getProjectFilter().getName(),
+					fieldMapping.getJiraStatusForQaKPI206());
+		}
+
 		// Iterating Over All issues history's statusUpdationLog and saving start and
 		// end date for each status
-		jiraIssueCustomHistories.forEach(
-				jiraIssueCustomHistory ->
-						createDateRangeForStatuses(
-								endDate,
-								startDate,
-								statusesWithStartAndEndDate,
-								jiraIssueCustomHistory,
-								fieldMapping));
+		if (CollectionUtils.isNotEmpty(jiraIssueCustomHistories)) {
+			jiraIssueCustomHistories.forEach(
+					jiraIssueCustomHistory ->
+							createDateRangeForStatuses(
+									endDate,
+									startDate,
+									statusesWithStartAndEndDate,
+									jiraIssueCustomHistory,
+									fieldMapping));
+		}
 
 		Map<String, Map<String, Integer>> dateWithStatusCount = new HashMap<>();
 		LocalDate tempStartDate = startDate;
@@ -285,12 +305,25 @@ public class FlowLoadSlingshotServiceImpl extends JiraBacklogKPIService<Double, 
 		List<String> doneStatus = new ArrayList<>();
 		if (doneStatusMap != null)
 			doneStatus = doneStatusMap.values().stream().map(String::toLowerCase).toList();
-		return !doneStatus.contains(status.toLowerCase())
-				&& (fieldMapping.getStoryFirstStatusKPI206().equalsIgnoreCase(status)
-						|| (CollectionUtils.isNotEmpty(fieldMapping.getJiraStatusForInProgressKPI206())
-								&& fieldMapping.getJiraStatusForInProgressKPI206().contains(status))
-						|| (CollectionUtils.isNotEmpty(fieldMapping.getJiraStatusForQaKPI206())
-								&& fieldMapping.getJiraStatusForQaKPI206().contains(status)));
+		if (org.apache.commons.lang3.StringUtils.isEmpty(fieldMapping.getStoryFirstStatusKPI206())
+				&& CollectionUtils.isEmpty(fieldMapping.getJiraStatusForInProgressKPI206())
+				&& CollectionUtils.isEmpty(fieldMapping.getJiraStatusForQaKPI206())) {
+			return false;
+		}
+		String statusLower = status.toLowerCase();
+		boolean inProgressMatch =
+				CollectionUtils.isNotEmpty(fieldMapping.getJiraStatusForInProgressKPI206())
+						&& fieldMapping.getJiraStatusForInProgressKPI206().stream()
+								.anyMatch(s -> s.equalsIgnoreCase(status));
+		boolean qaMatch =
+				CollectionUtils.isNotEmpty(fieldMapping.getJiraStatusForQaKPI206())
+						&& fieldMapping.getJiraStatusForQaKPI206().stream()
+								.anyMatch(s -> s.equalsIgnoreCase(status));
+		return !doneStatus.contains(statusLower)
+				&& (org.apache.commons.lang3.StringUtils.equalsIgnoreCase(
+								fieldMapping.getStoryFirstStatusKPI206(), status)
+						|| inProgressMatch
+						|| qaMatch);
 	}
 
 	private void populateTrendValueList(

--- a/src/main/java/com/publicissapient/kpidashboard/apis/jira/scrum/service/slingshot/SprintVelocitySlingshotServiceImpl.java
+++ b/src/main/java/com/publicissapient/kpidashboard/apis/jira/scrum/service/slingshot/SprintVelocitySlingshotServiceImpl.java
@@ -2,18 +2,23 @@ package com.publicissapient.kpidashboard.apis.jira.scrum.service.slingshot;
 
 import static com.publicissapient.kpidashboard.common.constant.CommonConstant.HIERARCHY_LEVEL_ID_PROJECT;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.YearMonth;
+import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 
 import org.apache.commons.collections4.CollectionUtils;
@@ -43,6 +48,7 @@ import com.publicissapient.kpidashboard.apis.util.KPIExcelUtility;
 import com.publicissapient.kpidashboard.apis.util.KpiDataHelper;
 import com.publicissapient.kpidashboard.common.constant.CommonConstant;
 import com.publicissapient.kpidashboard.common.model.application.DataCount;
+import com.publicissapient.kpidashboard.common.model.application.DataCountGroup;
 import com.publicissapient.kpidashboard.common.model.application.FieldMapping;
 import com.publicissapient.kpidashboard.common.model.jira.JiraIssue;
 import com.publicissapient.kpidashboard.common.repository.jira.JiraIssueRepository;
@@ -57,7 +63,16 @@ public class SprintVelocitySlingshotServiceImpl
 
 	private static final String VELOCITY = "Velocity";
 	private static final String AVERAGE_VELOCITY = "Average Velocity";
+	private static final String COMMITTED_SCOPE = "Committed Scope";
 	private static final String JIRA_ISSUES = "JIRAISSUES";
+	private static final String NON_VELOCITY_ISSUES = "NON_VELOCITY_ISSUES";
+	private static final String WEEKLY = "Weekly";
+	private static final String BI_WEEKLY = "Bi-Weekly";
+	private static final String MONTHLY = "Monthly";
+	private static final DateTimeFormatter WEEK_LABEL_FORMATTER =
+			DateTimeFormatter.ofPattern("dd-MMM-yyyy", Locale.ENGLISH);
+	private static final DateTimeFormatter MONTH_LABEL_FORMATTER =
+			DateTimeFormatter.ofPattern("MMM-yyyy", Locale.ENGLISH);
 
 	@Autowired private CustomApiConfig customApiConfig;
 	@Autowired private ConfigHelperService configHelperService;
@@ -102,7 +117,26 @@ public class SprintVelocitySlingshotServiceImpl
 		calculateAggregatedValue(root, nodeWiseKPIValue, KPICode.SPRINT_VELOCITY);
 		List<DataCount> trendValues =
 				getTrendValues(kpiRequest, kpiElement, nodeWiseKPIValue, KPICode.SPRINT_VELOCITY);
-		kpiElement.setTrendValueList(trendValues);
+
+		if (customApiConfig.isSlingshotSprintVelocityMultiGranularity()) {
+			List<DataCountGroup> groups = new ArrayList<>();
+			DataCountGroup weeklyGroup = new DataCountGroup();
+			weeklyGroup.setFilter(WEEKLY);
+			weeklyGroup.setValue(trendValues);
+			groups.add(weeklyGroup);
+			DataCountGroup biWeeklyGroup = new DataCountGroup();
+			biWeeklyGroup.setFilter(BI_WEEKLY);
+			biWeeklyGroup.setValue(wrapAggregated(trendValues, this::aggregateWeeklyToBiWeekly));
+			groups.add(biWeeklyGroup);
+			DataCountGroup monthlyGroup = new DataCountGroup();
+			monthlyGroup.setFilter(MONTHLY);
+			monthlyGroup.setValue(wrapAggregated(trendValues, this::aggregateWeeklyToMonthly));
+			groups.add(monthlyGroup);
+			kpiElement.setTrendValueList(groups);
+		} else {
+			kpiElement.setTrendValueList(trendValues);
+		}
+
 		log.debug(
 				"[SPRINT-VELOCITY-AGGREGATED-VALUE][{}]. Aggregated Value at each level in the tree {}",
 				kpiRequest.getRequestTrackerId(),
@@ -131,25 +165,45 @@ public class SprintVelocitySlingshotServiceImpl
 		List<String> closedStatuses =
 				CollectionUtils.isEmpty(fieldMapping.getJiraTicketClosedStatus())
 						? new ArrayList<>()
-						: fieldMapping.getJiraTicketClosedStatus();
+						: new ArrayList<>(fieldMapping.getJiraTicketClosedStatus());
 		closedStatuses.addAll(
 				CollectionUtils.isEmpty(fieldMapping.getJiraIterationCompletionStatusKPI205())
 						? List.of()
 						: fieldMapping.getJiraIterationCompletionStatusKPI205());
+
+		List<String> issueTypesKPI205 =
+				CollectionUtils.isEmpty(fieldMapping.getJiraIterationIssueTypeKPI205())
+						? List.of()
+						: fieldMapping.getJiraIterationIssueTypeKPI205().stream()
+								.map(String::toLowerCase)
+								.toList();
 
 		List<JiraIssue> jiraIssueList =
 				jiraIssueRepository.findByBasicProjectConfigId(basicProjectConfigId.toString());
 
 		LocalDateTime endDateTime = LocalDateTime.now();
 		LocalDateTime startDateTime = endDateTime.minusWeeks(11);
+		List<String> closedStatusesLower = closedStatuses.stream().map(String::toLowerCase).toList();
+
 		List<JiraIssue> jiraIssuesFiltered =
 				jiraIssueList.stream()
 						.filter(
 								jiraIssue ->
-										closedStatuses.stream()
-														.map(String::toLowerCase)
-														.toList()
-														.contains(jiraIssue.getStatus().toLowerCase())
+										(issueTypesKPI205.isEmpty()
+														|| issueTypesKPI205.contains(jiraIssue.getTypeName().toLowerCase()))
+												&& closedStatusesLower.contains(jiraIssue.getStatus().toLowerCase())
+												&& DateUtil.isWithinDateTimeRange(
+														DateUtil.convertToUTCLocalDateTime(jiraIssue.getChangeDate()),
+														startDateTime,
+														endDateTime))
+						.toList();
+
+		List<JiraIssue> nonVelocityIssues =
+				jiraIssueList.stream()
+						.filter(
+								jiraIssue ->
+										(issueTypesKPI205.isEmpty()
+														|| issueTypesKPI205.contains(jiraIssue.getTypeName().toLowerCase()))
 												&& DateUtil.isWithinDateTimeRange(
 														DateUtil.convertToUTCLocalDateTime(jiraIssue.getChangeDate()),
 														startDateTime,
@@ -157,6 +211,7 @@ public class SprintVelocitySlingshotServiceImpl
 						.toList();
 
 		resultListMap.put(JIRA_ISSUES, jiraIssuesFiltered);
+		resultListMap.put(NON_VELOCITY_ISSUES, nonVelocityIssues);
 
 		return resultListMap;
 	}
@@ -208,6 +263,8 @@ public class SprintVelocitySlingshotServiceImpl
 		log.info("Sprint Velocity taking fetchKPIDataFromDb {}", System.currentTimeMillis() - time);
 
 		List<JiraIssue> allJiraIssue = (List<JiraIssue>) sprintVelocityStoryMap.get(JIRA_ISSUES);
+		List<JiraIssue> allNonVelocityIssues =
+				(List<JiraIssue>) sprintVelocityStoryMap.get(NON_VELOCITY_ISSUES);
 
 		FieldMapping fieldMapping =
 				configHelperService
@@ -216,6 +273,17 @@ public class SprintVelocitySlingshotServiceImpl
 
 		Map<String, Set<JiraIssue>> jiraIssuesByDateRange = new LinkedHashMap<>();
 		Map<String, Double> velocityByDateRange = new LinkedHashMap<>();
+		Map<String, Double> committedScopeByDateRange = new LinkedHashMap<>();
+
+		Map<String, LocalDateTime> issueDateTimeCache = new HashMap<>();
+		allJiraIssue.forEach(
+				ji ->
+						issueDateTimeCache.put(
+								ji.getNumber(), DateUtil.convertToUTCLocalDateTime(ji.getChangeDate())));
+		allNonVelocityIssues.forEach(
+				ji ->
+						issueDateTimeCache.putIfAbsent(
+								ji.getNumber(), DateUtil.convertToUTCLocalDateTime(ji.getChangeDate())));
 
 		for (int i = 0; i < 12; i++) {
 			CustomDateRange periodRange =
@@ -226,15 +294,31 @@ public class SprintVelocitySlingshotServiceImpl
 							.filter(
 									jiraIssue ->
 											DateUtil.isWithinDateTimeRange(
-													DateUtil.convertToUTCLocalDateTime(jiraIssue.getChangeDate()),
+													issueDateTimeCache.get(jiraIssue.getNumber()),
 													periodRange.getStartDateTime(),
 													periodRange.getEndDateTime()))
 							.collect(Collectors.toSet());
+
+			Set<JiraIssue> nonVelocityIssuesSet =
+					allNonVelocityIssues.stream()
+							.filter(
+									jiraIssue ->
+											DateUtil.isWithinDateTimeRange(
+													issueDateTimeCache.get(jiraIssue.getNumber()),
+													periodRange.getStartDateTime(),
+													periodRange.getEndDateTime()))
+							.collect(Collectors.toSet());
+
 			double periodSpringVelocity;
+			double periodCommittedScope;
 			if (StringUtils.isNotEmpty(fieldMapping.getEstimationCriteria())
 					&& fieldMapping.getEstimationCriteria().equalsIgnoreCase(CommonConstant.STORY_POINT)) {
 				periodSpringVelocity =
 						issueDetailsSet.stream()
+								.mapToDouble(ji -> Optional.ofNullable(ji.getStoryPoints()).orElse(0.0d))
+								.sum();
+				periodCommittedScope =
+						nonVelocityIssuesSet.stream()
 								.mapToDouble(ji -> Optional.ofNullable(ji.getStoryPoints()).orElse(0.0d))
 								.sum();
 			} else {
@@ -247,26 +331,36 @@ public class SprintVelocitySlingshotServiceImpl
 								.sum();
 				double inHours = totalOriginalEstimate / 60;
 				periodSpringVelocity = inHours / fieldMapping.getStoryPointToHourMapping();
+
+				double nonVelocityEstimate =
+						nonVelocityIssuesSet.stream()
+								.filter(
+										jiraIssue ->
+												Objects.nonNull(jiraIssue.getAggregateTimeOriginalEstimateMinutes()))
+								.mapToDouble(JiraIssue::getAggregateTimeOriginalEstimateMinutes)
+								.sum();
+				double nonVelocityHours = nonVelocityEstimate / 60;
+				periodCommittedScope = nonVelocityHours / fieldMapping.getStoryPointToHourMapping();
 			}
 
 			String dateLabel = KpiHelperService.getDateRange(periodRange, CommonConstant.WEEK);
 
 			jiraIssuesByDateRange.put(dateLabel, issueDetailsSet);
 			velocityByDateRange.put(dateLabel, periodSpringVelocity);
+			committedScopeByDateRange.put(dateLabel, periodCommittedScope);
 
 			endDate = DeveloperKpiHelper.getNextRangeDate(CommonConstant.WEEK, endDate);
 		}
 
 		List<KPIExcelData> excelData = new ArrayList<>();
+		populateExcelDataObject(
+				requestTrackerId, excelData, new HashSet<>(allJiraIssue), projectNode, fieldMapping);
 		Map<String, Integer> avgVelocityCount = new HashMap<>();
 
 		velocityByDateRange.forEach(
 				(key, value) -> {
 					String projId = projectNode.getProjectFilter().getBasicProjectConfigId().toString();
 					String trendLineName = projectNode.getProjectFilter().getName();
-
-					populateExcelDataObject(
-							requestTrackerId, excelData, new HashSet<>(allJiraIssue), projectNode, fieldMapping);
 
 					DataCount dataCount = new DataCount();
 					dataCount.setData(String.valueOf(roundingOff(value)));
@@ -279,11 +373,14 @@ public class SprintVelocitySlingshotServiceImpl
 					}
 
 					double averageVelocity = getAverageVelocity(velocityByDateRange, key);
+					double committedScope = committedScopeByDateRange.getOrDefault(key, 0.0);
 					if (averageVelocity >= 0) {
 						dataCount.setLineValue(roundingOff(averageVelocity));
+						dataCount.setAggregationValue(roundingOff(committedScope));
 						Map<String, Object> hoverValue = new HashMap<>();
-						hoverValue.put(AVERAGE_VELOCITY, roundingOff(averageVelocity));
 						hoverValue.put(VELOCITY, roundingOff((Double) dataCount.getValue()));
+						hoverValue.put(AVERAGE_VELOCITY, roundingOff(averageVelocity));
+						hoverValue.put(COMMITTED_SCOPE, roundingOff(committedScope));
 						dataCount.setHoverValue(hoverValue);
 						avgVelocityCount.put(projId, avgVelocityCount.get(projId) + 1);
 					} else {
@@ -354,5 +451,115 @@ public class SprintVelocitySlingshotServiceImpl
 	public Double calculateThresholdValue(FieldMapping fieldMapping) {
 		return calculateThresholdValue(
 				fieldMapping.getThresholdValueKPI205(), KPICode.SPRINT_VELOCITY.getKpiId());
+	}
+
+	@SuppressWarnings("unchecked")
+	private List<DataCount> wrapAggregated(
+			List<DataCount> projectDataCounts, Function<List<DataCount>, List<DataCount>> aggregator) {
+		List<DataCount> result = new ArrayList<>();
+		for (DataCount projectDc : projectDataCounts) {
+			if (projectDc.getValue() instanceof List<?> innerList) {
+				DataCount wrapper = new DataCount();
+				wrapper.setData(projectDc.getData());
+				wrapper.setValue(aggregator.apply((List<DataCount>) innerList));
+				result.add(wrapper);
+			}
+		}
+		return result;
+	}
+
+	private List<DataCount> aggregateWeeklyToBiWeekly(List<DataCount> weeklyList) {
+		List<DataCount> biWeeklyList = new ArrayList<>();
+		for (int i = 0; i < weeklyList.size(); i += 2) {
+			List<DataCount> pair = weeklyList.subList(i, Math.min(i + 2, weeklyList.size()));
+			double pairVelocity =
+					pair.stream()
+							.mapToDouble(dc -> dc.getValue() instanceof Number n ? n.doubleValue() : 0.0)
+							.sum();
+			double pairCommittedScope =
+					pair.stream()
+							.filter(dc -> dc.getAggregationValue() instanceof Number)
+							.mapToDouble(dc -> ((Number) dc.getAggregationValue()).doubleValue())
+							.sum();
+			double avgLineValue =
+					pair.stream()
+							.filter(dc -> dc.getLineValue() instanceof Number)
+							.mapToDouble(dc -> ((Number) dc.getLineValue()).doubleValue())
+							.average()
+							.orElse(0.0);
+			String firstId = pair.get(0).getsSprintID();
+			String lastId = pair.get(pair.size() - 1).getsSprintID();
+			String startPart =
+					firstId != null && firstId.contains(" to ") ? firstId.split(" to ")[0].trim() : firstId;
+			String endPart =
+					lastId != null && lastId.contains(" to ") ? lastId.split(" to ")[1].trim() : lastId;
+			String biWeekLabel = startPart + " to " + endPart;
+			DataCount dc = new DataCount();
+			dc.setSProjectName(pair.get(0).getSProjectName());
+			dc.setSSprintID(biWeekLabel);
+			dc.setSSprintName(biWeekLabel);
+			dc.setData(String.valueOf(roundingOff(pairVelocity)));
+			dc.setValue(roundingOff(pairVelocity));
+			dc.setLineValue(roundingOff(avgLineValue));
+			dc.setAggregationValue(roundingOff(pairCommittedScope));
+			Map<String, Object> hoverValue = new HashMap<>();
+			hoverValue.put(VELOCITY, roundingOff(pairVelocity));
+			hoverValue.put(AVERAGE_VELOCITY, roundingOff(avgLineValue));
+			hoverValue.put(COMMITTED_SCOPE, roundingOff(pairCommittedScope));
+			dc.setHoverValue(hoverValue);
+			biWeeklyList.add(dc);
+		}
+		return biWeeklyList;
+	}
+
+	private List<DataCount> aggregateWeeklyToMonthly(List<DataCount> weeklyList) {
+		Map<YearMonth, List<DataCount>> byMonth = new LinkedHashMap<>();
+		for (DataCount dc : weeklyList) {
+			String sprintId = dc.getsSprintID();
+			if (sprintId == null) continue;
+			try {
+				String startPart =
+						sprintId.contains(" to ") ? sprintId.split(" to ")[0].trim() : sprintId.trim();
+				LocalDate startDate = LocalDate.parse(startPart, WEEK_LABEL_FORMATTER);
+				byMonth.computeIfAbsent(YearMonth.from(startDate), k -> new ArrayList<>()).add(dc);
+			} catch (Exception e) {
+				log.warn("Could not parse week label for monthly grouping: {}", sprintId);
+			}
+		}
+		List<DataCount> monthlyList = new ArrayList<>();
+		byMonth.forEach(
+				(ym, monthSlice) -> {
+					double monthVelocity =
+							monthSlice.stream()
+									.mapToDouble(dc -> dc.getValue() instanceof Number n ? n.doubleValue() : 0.0)
+									.sum();
+					double monthCommittedScope =
+							monthSlice.stream()
+									.filter(dc -> dc.getAggregationValue() instanceof Number)
+									.mapToDouble(dc -> ((Number) dc.getAggregationValue()).doubleValue())
+									.sum();
+					double avgLineValue =
+							monthSlice.stream()
+									.filter(dc -> dc.getLineValue() instanceof Number)
+									.mapToDouble(dc -> ((Number) dc.getLineValue()).doubleValue())
+									.average()
+									.orElse(0.0);
+					String monthLabel = ym.format(MONTH_LABEL_FORMATTER);
+					DataCount dc = new DataCount();
+					dc.setSProjectName(monthSlice.get(0).getSProjectName());
+					dc.setSSprintID(monthLabel);
+					dc.setSSprintName(monthLabel);
+					dc.setData(String.valueOf(roundingOff(monthVelocity)));
+					dc.setValue(roundingOff(monthVelocity));
+					dc.setLineValue(roundingOff(avgLineValue));
+					dc.setAggregationValue(roundingOff(monthCommittedScope));
+					Map<String, Object> hoverValue = new HashMap<>();
+					hoverValue.put(VELOCITY, roundingOff(monthVelocity));
+					hoverValue.put(AVERAGE_VELOCITY, roundingOff(avgLineValue));
+					hoverValue.put(COMMITTED_SCOPE, roundingOff(monthCommittedScope));
+					dc.setHoverValue(hoverValue);
+					monthlyList.add(dc);
+				});
+		return monthlyList;
 	}
 }

--- a/src/main/java/com/publicissapient/kpidashboard/apis/jira/scrum/service/slingshot/SprintVelocitySlingshotServiceImpl.java
+++ b/src/main/java/com/publicissapient/kpidashboard/apis/jira/scrum/service/slingshot/SprintVelocitySlingshotServiceImpl.java
@@ -6,6 +6,7 @@ import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -55,7 +56,7 @@ public class SprintVelocitySlingshotServiceImpl
 		extends JiraKPIService<Double, List<Object>, Map<String, Object>> {
 
 	private static final String VELOCITY = "Velocity";
-	private static final String AVERAGE_VELOCITY = "AverageVelocity";
+	private static final String AVERAGE_VELOCITY = "Average Velocity";
 	private static final String JIRA_ISSUES = "JIRAISSUES";
 
 	@Autowired private CustomApiConfig customApiConfig;
@@ -213,8 +214,8 @@ public class SprintVelocitySlingshotServiceImpl
 						.getFieldMappingMap()
 						.get(projectNode.getProjectFilter().getBasicProjectConfigId());
 
-		Map<String, Set<JiraIssue>> jiraIssuesByDateRange = new HashMap<>();
-		Map<String, Double> velocityByDateRange = new HashMap<>();
+		Map<String, Set<JiraIssue>> jiraIssuesByDateRange = new LinkedHashMap<>();
+		Map<String, Double> velocityByDateRange = new LinkedHashMap<>();
 
 		for (int i = 0; i < 12; i++) {
 			CustomDateRange periodRange =
@@ -279,7 +280,7 @@ public class SprintVelocitySlingshotServiceImpl
 
 					double averageVelocity = getAverageVelocity(velocityByDateRange, key);
 					if (averageVelocity >= 0) {
-						dataCount.setLineValue(averageVelocity);
+						dataCount.setLineValue(roundingOff(averageVelocity));
 						Map<String, Object> hoverValue = new HashMap<>();
 						hoverValue.put(AVERAGE_VELOCITY, roundingOff(averageVelocity));
 						hoverValue.put(VELOCITY, roundingOff((Double) dataCount.getValue()));

--- a/src/main/java/com/publicissapient/kpidashboard/apis/model/KPIExcelData.java
+++ b/src/main/java/com/publicissapient/kpidashboard/apis/model/KPIExcelData.java
@@ -372,7 +372,7 @@ public class KPIExcelData {
 	private String createdDuringIteration;
 
 	@JsonProperty("Count")
-	private Map<String, Integer> count;
+	private Map<String, String> count;
 
 	@JsonProperty("Scope")
 	private String scopeValue;

--- a/src/main/java/com/publicissapient/kpidashboard/apis/mongock/rollback/release_1710/FlowVelocitySlingshotKpiColumnConfigChangeUnit.java
+++ b/src/main/java/com/publicissapient/kpidashboard/apis/mongock/rollback/release_1710/FlowVelocitySlingshotKpiColumnConfigChangeUnit.java
@@ -1,0 +1,89 @@
+/*
+ *  Copyright 2024 <Sapient Corporation>
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and limitations under the
+ *  License.
+ */
+
+package com.publicissapient.kpidashboard.apis.mongock.rollback.release_1710;
+
+import java.util.List;
+
+import org.bson.Document;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.query.Criteria;
+import org.springframework.data.mongodb.core.query.Query;
+
+import com.mongodb.client.model.ReplaceOptions;
+
+import io.mongock.api.annotations.ChangeUnit;
+import io.mongock.api.annotations.Execution;
+import io.mongock.api.annotations.RollbackExecution;
+
+@ChangeUnit(
+		id = "flow_velocity_slingshot_kpi_column_config",
+		order = "17115",
+		author = "kunkambl",
+		systemVersion = "17.1.0")
+public class FlowVelocitySlingshotKpiColumnConfigChangeUnit {
+
+	private static final String KPI_ID = "kpiId";
+	private static final String KPI_205 = "kpi205";
+	private static final String KPI_COLUMN_CONFIGS = "kpi_column_configs";
+	private static final String BASIC_PROJECT_CONFIG_ID = "basicProjectConfigId";
+
+	private final MongoTemplate mongoTemplate;
+
+	public FlowVelocitySlingshotKpiColumnConfigChangeUnit(MongoTemplate mongoTemplate) {
+		this.mongoTemplate = mongoTemplate;
+	}
+
+	@Execution
+	public void execute() {
+		mongoTemplate.remove(
+				new Query(Criteria.where(KPI_ID).is(KPI_205).and(BASIC_PROJECT_CONFIG_ID).isNull()),
+				KPI_COLUMN_CONFIGS);
+	}
+
+	@RollbackExecution
+	public void rollback() {
+		Document filter = new Document(BASIC_PROJECT_CONFIG_ID, null).append(KPI_ID, KPI_205);
+
+		Document replacement =
+				new Document(BASIC_PROJECT_CONFIG_ID, null)
+						.append(KPI_ID, KPI_205)
+						.append(
+								"kpiColumnDetails",
+								List.of(
+										columnDetail("Sprint Name", 1),
+										columnDetail("Issue ID", 2),
+										columnDetail("Issue Description", 3),
+										columnDetail("Squad", 4),
+										columnDetail("Issue Type", 5),
+										columnDetail("Priority", 6),
+										columnDetail("Story Points", 7),
+										columnDetail("Original Time Estimate (in hours)", 8),
+										columnDetail("Time Spent (in hours)", 9)));
+
+		mongoTemplate
+				.getCollection(KPI_COLUMN_CONFIGS)
+				.replaceOne(filter, replacement, new ReplaceOptions().upsert(true));
+	}
+
+	private Document columnDetail(String name, int order) {
+		return new Document()
+				.append("columnName", name)
+				.append("order", order)
+				.append("isShown", true)
+				.append("isDefault", true);
+	}
+}

--- a/src/main/java/com/publicissapient/kpidashboard/apis/mongock/upgrade/release_1710/CycleTimeSlingshotExcelColumnsChangeUnit.java
+++ b/src/main/java/com/publicissapient/kpidashboard/apis/mongock/upgrade/release_1710/CycleTimeSlingshotExcelColumnsChangeUnit.java
@@ -23,6 +23,8 @@ import org.springframework.data.mongodb.core.MongoTemplate;
 import org.springframework.data.mongodb.core.query.Criteria;
 import org.springframework.data.mongodb.core.query.Query;
 
+import com.mongodb.client.model.ReplaceOptions;
+
 import io.mongock.api.annotations.ChangeUnit;
 import io.mongock.api.annotations.Execution;
 import io.mongock.api.annotations.RollbackExecution;
@@ -67,7 +69,19 @@ public class CycleTimeSlingshotExcelColumnsChangeUnit {
 										columnDetail("Sprint Name", 4),
 										columnDetail("Group Map", 5)));
 
-		mongoTemplate.getCollection("kpi_column_configs").insertMany(List.of(doc, doc2));
+		ReplaceOptions upsertOptions = new ReplaceOptions().upsert(true);
+		mongoTemplate
+				.getCollection("kpi_column_configs")
+				.replaceOne(
+						new Document("basicProjectConfigId", null).append(KPI_ID, "kpi202"),
+						doc,
+						upsertOptions);
+		mongoTemplate
+				.getCollection("kpi_column_configs")
+				.replaceOne(
+						new Document("basicProjectConfigId", null).append(KPI_ID, "kpi204"),
+						doc2,
+						upsertOptions);
 	}
 
 	@RollbackExecution

--- a/src/main/java/com/publicissapient/kpidashboard/apis/mongock/upgrade/release_1710/CycleTimeSlingshotFieldMappingChangeUnit.java
+++ b/src/main/java/com/publicissapient/kpidashboard/apis/mongock/upgrade/release_1710/CycleTimeSlingshotFieldMappingChangeUnit.java
@@ -16,12 +16,12 @@
 
 package com.publicissapient.kpidashboard.apis.mongock.upgrade.release_1710;
 
-import java.util.List;
-
 import org.bson.Document;
 import org.springframework.data.mongodb.core.MongoTemplate;
 import org.springframework.data.mongodb.core.query.Criteria;
 import org.springframework.data.mongodb.core.query.Query;
+
+import com.mongodb.client.model.ReplaceOptions;
 
 import io.mongock.api.annotations.ChangeUnit;
 import io.mongock.api.annotations.Execution;
@@ -95,7 +95,16 @@ public class CycleTimeSlingshotFieldMappingChangeUnit {
 
 		mongoTemplate
 				.getCollection(FIELD_MAPPING_STRUCTURE)
-				.insertMany(List.of(issueTypeDoc, workflowGroupDoc));
+				.replaceOne(
+						new Document(FIELD_NAME, "jiraIssueTypeKPI202"),
+						issueTypeDoc,
+						new ReplaceOptions().upsert(true));
+		mongoTemplate
+				.getCollection(FIELD_MAPPING_STRUCTURE)
+				.replaceOne(
+						new Document(FIELD_NAME, "jiraIssueStatusGroupByCategoryKPI202"),
+						workflowGroupDoc,
+						new ReplaceOptions().upsert(true));
 	}
 
 	@RollbackExecution

--- a/src/main/java/com/publicissapient/kpidashboard/apis/mongock/upgrade/release_1710/CycleTimeSlingshotKpiChangeUnit.java
+++ b/src/main/java/com/publicissapient/kpidashboard/apis/mongock/upgrade/release_1710/CycleTimeSlingshotKpiChangeUnit.java
@@ -48,7 +48,7 @@ public class CycleTimeSlingshotKpiChangeUnit {
 						.append("defaultOrder", 1)
 						.append("kpiCategory", "Slingshot")
 						.append("kpiSource", "Jira")
-						.append("groupId", 34)
+						.append("groupId", 45)
 						.append("thresholdValue", "")
 						.append("kanban", false)
 						.append("chartType", "stacked-bar-chart")

--- a/src/main/java/com/publicissapient/kpidashboard/apis/mongock/upgrade/release_1710/CycleTimeSlingshotKpiChangeUnit.java
+++ b/src/main/java/com/publicissapient/kpidashboard/apis/mongock/upgrade/release_1710/CycleTimeSlingshotKpiChangeUnit.java
@@ -21,6 +21,8 @@ import org.springframework.data.mongodb.core.MongoTemplate;
 import org.springframework.data.mongodb.core.query.Criteria;
 import org.springframework.data.mongodb.core.query.Query;
 
+import com.mongodb.client.model.ReplaceOptions;
+
 import io.mongock.api.annotations.ChangeUnit;
 import io.mongock.api.annotations.Execution;
 import io.mongock.api.annotations.RollbackExecution;
@@ -78,7 +80,10 @@ public class CycleTimeSlingshotKpiChangeUnit {
 						.append("combinedKpiSource", "Jira/Azure/Rally")
 						.append("aggregationCriteria", "sum");
 
-		mongoTemplate.getCollection("kpi_master").insertOne(kpiDocument);
+		mongoTemplate
+				.getCollection("kpi_master")
+				.replaceOne(
+						new Document("kpiId", "kpi202"), kpiDocument, new ReplaceOptions().upsert(true));
 	}
 
 	@RollbackExecution

--- a/src/main/java/com/publicissapient/kpidashboard/apis/mongock/upgrade/release_1710/CycleTimeTrendSlingshotKpiChangeUnit.java
+++ b/src/main/java/com/publicissapient/kpidashboard/apis/mongock/upgrade/release_1710/CycleTimeTrendSlingshotKpiChangeUnit.java
@@ -21,6 +21,8 @@ import org.springframework.data.mongodb.core.MongoTemplate;
 import org.springframework.data.mongodb.core.query.Criteria;
 import org.springframework.data.mongodb.core.query.Query;
 
+import com.mongodb.client.model.ReplaceOptions;
+
 import io.mongock.api.annotations.ChangeUnit;
 import io.mongock.api.annotations.Execution;
 import io.mongock.api.annotations.RollbackExecution;
@@ -78,7 +80,10 @@ public class CycleTimeTrendSlingshotKpiChangeUnit {
 						.append("combinedKpiSource", "Jira/Azure/Rally")
 						.append("aggregationCriteria", "sum");
 
-		mongoTemplate.getCollection("kpi_master").insertOne(kpiDocument);
+		mongoTemplate
+				.getCollection("kpi_master")
+				.replaceOne(
+						new Document("kpiId", "kpi204"), kpiDocument, new ReplaceOptions().upsert(true));
 	}
 
 	@RollbackExecution

--- a/src/main/java/com/publicissapient/kpidashboard/apis/mongock/upgrade/release_1710/CycleTimeTrendSlingshotKpiChangeUnit.java
+++ b/src/main/java/com/publicissapient/kpidashboard/apis/mongock/upgrade/release_1710/CycleTimeTrendSlingshotKpiChangeUnit.java
@@ -48,7 +48,7 @@ public class CycleTimeTrendSlingshotKpiChangeUnit {
 						.append("defaultOrder", 2)
 						.append("kpiCategory", "Slingshot")
 						.append("kpiSource", "Jira")
-						.append("groupId", 45)
+						.append("groupId", 34)
 						.append("thresholdValue", "")
 						.append("kanban", false)
 						.append("chartType", "line")

--- a/src/main/java/com/publicissapient/kpidashboard/apis/mongock/upgrade/release_1710/FlowDistributionSlingshotChangeUnit.java
+++ b/src/main/java/com/publicissapient/kpidashboard/apis/mongock/upgrade/release_1710/FlowDistributionSlingshotChangeUnit.java
@@ -65,7 +65,7 @@ public class FlowDistributionSlingshotChangeUnit {
 									new Document(KEY_COLUMN_NAME, "Date")
 											.append(KEY_ORDER, 1)
 											.append(KEY_IS_SHOWN, true)
-											.append(KEY_IS_DEFAULT, false)
+											.append(KEY_IS_DEFAULT, true)
 								});
 
 		mongoTemplate.insert(kpiColumnConfig, KPI_EXCEL_COLUMN_CONFIG);

--- a/src/main/java/com/publicissapient/kpidashboard/apis/mongock/upgrade/release_1710/FlowDistributionSlingshotChangeUnit.java
+++ b/src/main/java/com/publicissapient/kpidashboard/apis/mongock/upgrade/release_1710/FlowDistributionSlingshotChangeUnit.java
@@ -1,10 +1,11 @@
 package com.publicissapient.kpidashboard.apis.mongock.upgrade.release_1710;
 
-import java.util.Arrays;
 import java.util.List;
 
 import org.bson.Document;
 import org.springframework.data.mongodb.core.MongoTemplate;
+
+import com.mongodb.client.model.ReplaceOptions;
 
 import io.mongock.api.annotations.ChangeUnit;
 import io.mongock.api.annotations.Execution;
@@ -56,19 +57,22 @@ public class FlowDistributionSlingshotChangeUnit {
 	}
 
 	private void insertExcelColumnConfig() {
+		Document filter = new Document(KEY_BASIC_PROJECT_CONFIG_ID, null).append(KPI_ID, KPI_207);
+
 		Document kpiColumnConfig =
 				new Document(KEY_BASIC_PROJECT_CONFIG_ID, null)
 						.append(KPI_ID, KPI_207)
 						.append(
 								KEY_KPI_COLUMN_DETAILS,
-								new Document[] {
-									new Document(KEY_COLUMN_NAME, "Date")
-											.append(KEY_ORDER, 1)
-											.append(KEY_IS_SHOWN, true)
-											.append(KEY_IS_DEFAULT, true)
-								});
+								List.of(
+										new Document(KEY_COLUMN_NAME, "Date")
+												.append(KEY_ORDER, 1)
+												.append(KEY_IS_SHOWN, true)
+												.append(KEY_IS_DEFAULT, true)));
 
-		mongoTemplate.insert(kpiColumnConfig, KPI_EXCEL_COLUMN_CONFIG);
+		mongoTemplate
+				.getCollection(KPI_EXCEL_COLUMN_CONFIG)
+				.replaceOne(filter, kpiColumnConfig, new ReplaceOptions().upsert(true));
 	}
 
 	private void insertFlowDistributionKpi() {
@@ -114,7 +118,9 @@ public class FlowDistributionSlingshotChangeUnit {
 						.append("isAdditionalFilterSupport", false)
 						.append("calculateMaturity", false);
 
-		mongoTemplate.getCollection(KPI_MASTER).insertOne(kpiDocument);
+		mongoTemplate
+				.getCollection(KPI_MASTER)
+				.replaceOne(new Document(KPI_ID, KPI_207), kpiDocument, new ReplaceOptions().upsert(true));
 	}
 
 	private void insertFieldMappingStructure() {
@@ -146,7 +152,16 @@ public class FlowDistributionSlingshotChangeUnit {
 
 		mongoTemplate
 				.getCollection(FIELD_MAPPING_STRUCTURE)
-				.insertMany(Arrays.asList(fieldMappingDocument, closeStatusDocument));
+				.replaceOne(
+						new Document(FIELD_NAME, "jiraIssueTypeNamesKPI207"),
+						fieldMappingDocument,
+						new ReplaceOptions().upsert(true));
+		mongoTemplate
+				.getCollection(FIELD_MAPPING_STRUCTURE)
+				.replaceOne(
+						new Document(FIELD_NAME, "jiraIssueClosedStateKPI207"),
+						closeStatusDocument,
+						new ReplaceOptions().upsert(true));
 	}
 
 	@RollbackExecution

--- a/src/main/java/com/publicissapient/kpidashboard/apis/mongock/upgrade/release_1710/FlowEfficiencySlingshotChangeUnit.java
+++ b/src/main/java/com/publicissapient/kpidashboard/apis/mongock/upgrade/release_1710/FlowEfficiencySlingshotChangeUnit.java
@@ -8,6 +8,8 @@ import org.springframework.data.mongodb.core.MongoTemplate;
 import org.springframework.data.mongodb.core.query.Criteria;
 import org.springframework.data.mongodb.core.query.Query;
 
+import com.mongodb.client.model.ReplaceOptions;
+
 import io.mongock.api.annotations.ChangeUnit;
 import io.mongock.api.annotations.Execution;
 import io.mongock.api.annotations.RollbackExecution;
@@ -75,10 +77,13 @@ public class FlowEfficiencySlingshotChangeUnit {
 						.append("aggregationCriteria", "average")
 						.append("isAdditionalFilterSupport", false)
 						.append("calculateMaturity", false);
-		mongoTemplate.getCollection(KPI_MASTER).insertOne(kpiDocument);
+		mongoTemplate
+				.getCollection(KPI_MASTER)
+				.replaceOne(new Document(KPI_ID, KPI_203), kpiDocument, new ReplaceOptions().upsert(true));
 
+		Document filter = new Document("basicProjectConfigId", null).append(KPI_ID, KPI_203);
 		Document kpiColumnConfigDocument =
-				new Document()
+				new Document("basicProjectConfigId", null)
 						.append(KPI_ID, KPI_203)
 						.append(
 								"kpiColumnDetails",
@@ -91,7 +96,9 @@ public class FlowEfficiencySlingshotChangeUnit {
 										columnDoc("Total Time", 6),
 										columnDoc("Flow Efficiency", 7)));
 
-		mongoTemplate.getCollection(KPI_COLUMN_CONFIGS).insertOne(kpiColumnConfigDocument);
+		mongoTemplate
+				.getCollection(KPI_COLUMN_CONFIGS)
+				.replaceOne(filter, kpiColumnConfigDocument, new ReplaceOptions().upsert(true));
 	}
 
 	private Document columnDoc(String name, int orderVal) {
@@ -142,7 +149,22 @@ public class FlowEfficiencySlingshotChangeUnit {
 
 		mongoTemplate
 				.getCollection(FIELD_MAPPING_STRUCTURE)
-				.insertMany(Arrays.asList(waitStatusDocument, closeStatusDocument, thresholdDocument));
+				.replaceOne(
+						new Document(FIELD_NAME, "jiraIssueWaitStateKPI203"),
+						waitStatusDocument,
+						new ReplaceOptions().upsert(true));
+		mongoTemplate
+				.getCollection(FIELD_MAPPING_STRUCTURE)
+				.replaceOne(
+						new Document(FIELD_NAME, "jiraIssueClosedStateKPI203"),
+						closeStatusDocument,
+						new ReplaceOptions().upsert(true));
+		mongoTemplate
+				.getCollection(FIELD_MAPPING_STRUCTURE)
+				.replaceOne(
+						new Document(FIELD_NAME, "thresholdValueKPI203"),
+						thresholdDocument,
+						new ReplaceOptions().upsert(true));
 	}
 
 	@RollbackExecution

--- a/src/main/java/com/publicissapient/kpidashboard/apis/mongock/upgrade/release_1710/FlowLoadSlingshotKpiChangeUnit.java
+++ b/src/main/java/com/publicissapient/kpidashboard/apis/mongock/upgrade/release_1710/FlowLoadSlingshotKpiChangeUnit.java
@@ -78,7 +78,7 @@ public class FlowLoadSlingshotKpiChangeUnit {
 						.append("hideOverallFilter", false)
 						.append("kpiSource", "Jira")
 						.append("kanban", false)
-						.append("groupId", 35)
+						.append("groupId", 46)
 						.append(
 								"kpiInfo",
 								new Document()

--- a/src/main/java/com/publicissapient/kpidashboard/apis/mongock/upgrade/release_1710/FlowLoadSlingshotKpiChangeUnit.java
+++ b/src/main/java/com/publicissapient/kpidashboard/apis/mongock/upgrade/release_1710/FlowLoadSlingshotKpiChangeUnit.java
@@ -9,6 +9,7 @@ import org.springframework.data.mongodb.core.MongoTemplate;
 
 import com.mongodb.client.MongoCollection;
 import com.mongodb.client.MongoDatabase;
+import com.mongodb.client.model.ReplaceOptions;
 
 import io.mongock.api.annotations.ChangeUnit;
 import io.mongock.api.annotations.Execution;
@@ -102,7 +103,8 @@ public class FlowLoadSlingshotKpiChangeUnit {
 						.append("isAdditionalFilterSupport", false)
 						.append("combinedKpiSource", "Jira/Azure/Rally");
 
-		collection.insertOne(kpiMaster);
+		collection.replaceOne(
+				new Document(KPI_ID, KPI_206), kpiMaster, new ReplaceOptions().upsert(true));
 	}
 
 	private void insertFieldMappings(MongoTemplate mongoTemplate) {
@@ -139,7 +141,11 @@ public class FlowLoadSlingshotKpiChangeUnit {
 								WORKFLOW_STATUS_MAPPING,
 								"All workflow statuses used to identify issues in testing state"));
 
-		collection.insertMany(mappings);
+		for (Document mapping : mappings) {
+			String fieldName = mapping.getString(FIELD_NAME);
+			collection.replaceOne(
+					new Document(FIELD_NAME, fieldName), mapping, new ReplaceOptions().upsert(true));
+		}
 	}
 
 	private Document createFieldMapping(
@@ -173,10 +179,13 @@ public class FlowLoadSlingshotKpiChangeUnit {
 						createColumn("In-Development", 4, false),
 						createColumn("Open", 5, false));
 
+		Document filter = new Document("basicProjectConfigId", null).append(KPI_ID, KPI_206);
 		Document kpiColumnConfig =
-				new Document().append(KPI_ID, KPI_206).append("kpiColumnDetails", columns);
+				new Document("basicProjectConfigId", null)
+						.append(KPI_ID, KPI_206)
+						.append("kpiColumnDetails", columns);
 
-		collection.insertOne(kpiColumnConfig);
+		collection.replaceOne(filter, kpiColumnConfig, new ReplaceOptions().upsert(true));
 	}
 
 	private Document createColumn(String columnName, int order, boolean isDefault) {

--- a/src/main/java/com/publicissapient/kpidashboard/apis/mongock/upgrade/release_1710/FlowVelocitySlingshotKpiColumnConfigChangeUnit.java
+++ b/src/main/java/com/publicissapient/kpidashboard/apis/mongock/upgrade/release_1710/FlowVelocitySlingshotKpiColumnConfigChangeUnit.java
@@ -23,57 +23,58 @@ import org.springframework.data.mongodb.core.MongoTemplate;
 import org.springframework.data.mongodb.core.query.Criteria;
 import org.springframework.data.mongodb.core.query.Query;
 
+import com.mongodb.client.model.ReplaceOptions;
+
 import io.mongock.api.annotations.ChangeUnit;
 import io.mongock.api.annotations.Execution;
 import io.mongock.api.annotations.RollbackExecution;
 import lombok.RequiredArgsConstructor;
 
 @ChangeUnit(
-		id = "cycle_time_trend_slingshot_excel_insert",
-		order = "17106",
+		id = "flow_velocity_slingshot_kpi_column_config",
+		order = "17115",
 		author = "kunkambl",
 		systemVersion = "17.1.0")
 @RequiredArgsConstructor
-public class CycleTimeSlingshotExcelColumnsChangeUnit {
+public class FlowVelocitySlingshotKpiColumnConfigChangeUnit {
 
 	private static final String KPI_ID = "kpiId";
+	private static final String KPI_205 = "kpi205";
+	private static final String KPI_COLUMN_CONFIGS = "kpi_column_configs";
+	private static final String BASIC_PROJECT_CONFIG_ID = "basicProjectConfigId";
 
 	private final MongoTemplate mongoTemplate;
 
 	@Execution
 	public void execute() {
-		Document doc =
-				new Document()
-						.append("basicProjectConfigId", null)
-						.append(KPI_ID, "kpi202")
+		Document filter = new Document(BASIC_PROJECT_CONFIG_ID, null).append(KPI_ID, KPI_205);
+
+		Document replacement =
+				new Document(BASIC_PROJECT_CONFIG_ID, null)
+						.append(KPI_ID, KPI_205)
 						.append(
 								"kpiColumnDetails",
 								List.of(
-										columnDetail("Issue ID", 1),
-										columnDetail("Issue Type", 2),
+										columnDetail("Sprint Name", 1),
+										columnDetail("Issue ID", 2),
 										columnDetail("Issue Description", 3),
-										columnDetail("Group Map", 4)));
+										columnDetail("Squad", 4),
+										columnDetail("Issue Type", 5),
+										columnDetail("Priority", 6),
+										columnDetail("Story Points", 7),
+										columnDetail("Original Time Estimate (in hours)", 8),
+										columnDetail("Time Spent (in hours)", 9)));
 
-		Document doc2 =
-				new Document()
-						.append("basicProjectConfigId", null)
-						.append(KPI_ID, "kpi204")
-						.append(
-								"kpiColumnDetails",
-								List.of(
-										columnDetail("Issue ID", 1),
-										columnDetail("Issue Type", 2),
-										columnDetail("Issue Description", 3),
-										columnDetail("Sprint Name", 4),
-										columnDetail("Group Map", 5)));
-
-		mongoTemplate.getCollection("kpi_column_configs").insertMany(List.of(doc, doc2));
+		mongoTemplate
+				.getCollection(KPI_COLUMN_CONFIGS)
+				.replaceOne(filter, replacement, new ReplaceOptions().upsert(true));
 	}
 
 	@RollbackExecution
 	public void rollback() {
 		mongoTemplate.remove(
-				new Query(Criteria.where(KPI_ID).in("kpi204", "kpi202")), "kpi_column_configs");
+				new Query(Criteria.where(KPI_ID).is(KPI_205).and(BASIC_PROJECT_CONFIG_ID).isNull()),
+				KPI_COLUMN_CONFIGS);
 	}
 
 	private Document columnDetail(String name, int order) {

--- a/src/main/java/com/publicissapient/kpidashboard/apis/mongock/upgrade/release_1710/SlingshotKpiDefinitionFixChangeLog.java
+++ b/src/main/java/com/publicissapient/kpidashboard/apis/mongock/upgrade/release_1710/SlingshotKpiDefinitionFixChangeLog.java
@@ -1,0 +1,48 @@
+package com.publicissapient.kpidashboard.apis.mongock.upgrade.release_1710;
+
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.query.Criteria;
+import org.springframework.data.mongodb.core.query.Query;
+import org.springframework.data.mongodb.core.query.Update;
+
+import io.mongock.api.annotations.ChangeUnit;
+import io.mongock.api.annotations.Execution;
+import io.mongock.api.annotations.RollbackExecution;
+import lombok.RequiredArgsConstructor;
+
+@ChangeUnit(
+		id = "slingshot_kpi_definition_fix",
+		order = "17116",
+		author = "kunkambl",
+		systemVersion = "17.1.0")
+@RequiredArgsConstructor
+public class SlingshotKpiDefinitionFixChangeLog {
+
+	private static final String COLLECTION_KPI_MASTER = "kpi_master";
+	private static final String FIELD_KPI_ID = "kpiId";
+	private static final String KPI_DEFINITION = "kpiInfo.definition";
+
+	private final MongoTemplate mongoTemplate;
+
+	@Execution
+	public void execute() {
+		mongoTemplate.updateFirst(
+				Query.query(Criteria.where(FIELD_KPI_ID).is("kpi205")),
+				Update.update(
+						KPI_DEFINITION,
+						"Number of flow items completed per unit time, segmented by flow item type. Count of issues where status transitioned to Done within the period, grouped by Flow Item Type custom field."),
+				COLLECTION_KPI_MASTER);
+
+		mongoTemplate.updateFirst(
+				Query.query(Criteria.where(FIELD_KPI_ID).is("kpi206")),
+				Update.update(
+						KPI_DEFINITION,
+						"Number of flow items currently in progress in the value stream (WIP). Too high = thrashing; too low = underutilisation. Count of issues NOT in Backlog/To Do AND NOT in Done at point in time."),
+				COLLECTION_KPI_MASTER);
+	}
+
+	@RollbackExecution
+	public void rollback() {
+		/* rollback not needed */
+	}
+}

--- a/src/main/java/com/publicissapient/kpidashboard/apis/mongock/upgrade/release_1710/SlingshotKpisUpdateChangeLog.java
+++ b/src/main/java/com/publicissapient/kpidashboard/apis/mongock/upgrade/release_1710/SlingshotKpisUpdateChangeLog.java
@@ -36,11 +36,10 @@ public class SlingshotKpisUpdateChangeLog {
 				Query.query(Criteria.where(FIELD_KPI_ID).is("kpi205")),
 				Update.update(FIELD_X_AXIS_LABEL, "Weeks")
 						.set(FIELD_DEFAULT_ORDER, 3)
+						.set("kpiName", "Flow Velocity")
 						.set(
 								KPI_DEFINITION,
-								"""
-								Number of flow items completed per unit time, segmented by flow item type.
-								"Count of issues where status transitioned to Done within the period, grouped by Flow Item Type custom field."""));
+								"Number of flow items completed per unit time, segmented by flow item type. Count of issues where status transitioned to Done within the period, grouped by Flow Item Type custom field."));
 		bulkOps.updateOne(
 				Query.query(Criteria.where(FIELD_KPI_ID).is("kpi203")),
 				Update.update(FIELD_X_AXIS_LABEL, "Range")
@@ -54,19 +53,18 @@ public class SlingshotKpisUpdateChangeLog {
 						.set(
 								KPI_DEFINITION,
 								"Elapsed wall-clock time from when work started (entered an active state) to when it reached Done.")
-						.set("kpiWidth", 50));
+						.set("kpiWidth", 50)
+						.set("groupId", 45));
 		bulkOps.updateOne(
 				Query.query(Criteria.where(FIELD_KPI_ID).is("kpi204")),
-				Update.update(FIELD_DEFAULT_ORDER, 2));
+				Update.update(FIELD_DEFAULT_ORDER, 2).set("groupId", 34));
 		bulkOps.updateOne(
 				Query.query(Criteria.where(FIELD_KPI_ID).is("kpi206")),
 				Update.update(FIELD_DEFAULT_ORDER, 5)
 						.set(
 								KPI_DEFINITION,
-								"""
-						Number of flow items currently in progress in the value stream (WIP).
-						Too high = thrashing; too low = underutilisation.
-						"Count of issues NOT in Backlog/To Do AND NOT in Done at point in time.."""));
+								"Number of flow items currently in progress in the value stream (WIP). Too high = thrashing; too low = underutilisation. Count of issues NOT in Backlog/To Do AND NOT in Done at point in time.")
+						.set("groupId", 46));
 		bulkOps.updateOne(
 				Query.query(Criteria.where(FIELD_KPI_ID).is("kpi207")),
 				Update.update(FIELD_DEFAULT_ORDER, 6)

--- a/src/main/java/com/publicissapient/kpidashboard/apis/mongock/upgrade/release_1710/SprintVelocitySlingshotChangeUnit.java
+++ b/src/main/java/com/publicissapient/kpidashboard/apis/mongock/upgrade/release_1710/SprintVelocitySlingshotChangeUnit.java
@@ -5,6 +5,8 @@ import java.util.List;
 import org.bson.Document;
 import org.springframework.data.mongodb.core.MongoTemplate;
 
+import com.mongodb.client.model.ReplaceOptions;
+
 import io.mongock.api.annotations.ChangeUnit;
 import io.mongock.api.annotations.Execution;
 import io.mongock.api.annotations.RollbackExecution;
@@ -127,7 +129,9 @@ public class SprintVelocitySlingshotChangeUnit {
 						.append("yaxisOrder", null)
 						.append("combinedKpiSource", "Jira/Azure/Rally")
 						.append("forecastModel", "exponentialSmoothing");
-		mongoTemplate.getCollection(KPI_MASTER).insertOne(kpiDocument);
+		mongoTemplate
+				.getCollection(KPI_MASTER)
+				.replaceOne(new Document(KPI_ID, KPI_205), kpiDocument, new ReplaceOptions().upsert(true));
 	}
 
 	private Document trendDoc(String type, String operator) {
@@ -139,40 +143,45 @@ public class SprintVelocitySlingshotChangeUnit {
 	}
 
 	private void insertFieldMappingStructure() {
-		mongoTemplate
-				.getCollection(FIELD_MAPPING_STRUCTURE)
-				.insertMany(
-						List.of(
-								buildFieldMappingDoc(
-										new FieldMappingParams(
-												"thresholdValueKPI205",
-												"Target KPI Value",
-												"number",
-												null,
-												"Project Level Threshold"),
-										1,
-										6,
-										"Target KPI value denotes the bare minimum a project should maintain for a KPI. User should just input the number and the unit like percentage, hours will automatically be considered. If the threshold is empty, then a common target KPI line will be shown"),
-								buildFieldMappingDoc(
-										new FieldMappingParams(
-												"jiraIterationCompletionStatusKPI205",
-												"Status to identify completed issues",
-												CHIPS,
-												"workflow",
-												WORKFLOW_STATUS_MAPPING),
-										8,
-										4,
-										"All workflow statuses used to identify completed issues. If multiple statuses are specified, the first status an issue transitions to will be considered."),
-								buildFieldMappingDoc(
-										new FieldMappingParams(
-												"jiraIterationIssueTypeKPI205",
-												"Issue types filter for completed issues",
-												CHIPS,
-												"Issue_Type",
-												"Issue Types Mapping"),
-										1,
-										2,
-										"Completed issues of the specified issue types will be considered. If left blank, all issue types will be included by default.")));
+		List.of(
+						buildFieldMappingDoc(
+								new FieldMappingParams(
+										"thresholdValueKPI205",
+										"Target KPI Value",
+										"number",
+										null,
+										"Project Level Threshold"),
+								1,
+								6,
+								"Target KPI value denotes the bare minimum a project should maintain for a KPI. User should just input the number and the unit like percentage, hours will automatically be considered. If the threshold is empty, then a common target KPI line will be shown"),
+						buildFieldMappingDoc(
+								new FieldMappingParams(
+										"jiraIterationCompletionStatusKPI205",
+										"Status to identify completed issues",
+										CHIPS,
+										"workflow",
+										WORKFLOW_STATUS_MAPPING),
+								8,
+								4,
+								"All workflow statuses used to identify completed issues. If multiple statuses are specified, the first status an issue transitions to will be considered."),
+						buildFieldMappingDoc(
+								new FieldMappingParams(
+										"jiraIterationIssueTypeKPI205",
+										"Issue types filter for completed issues",
+										CHIPS,
+										"Issue_Type",
+										"Issue Types Mapping"),
+								1,
+								2,
+								"Completed issues of the specified issue types will be considered. If left blank, all issue types will be included by default."))
+				.forEach(
+						doc ->
+								mongoTemplate
+										.getCollection(FIELD_MAPPING_STRUCTURE)
+										.replaceOne(
+												new Document(FIELD_NAME, doc.getString(FIELD_NAME)),
+												doc,
+												new ReplaceOptions().upsert(true)));
 	}
 
 	private record FieldMappingParams(
@@ -221,7 +230,10 @@ public class SprintVelocitySlingshotChangeUnit {
 										columnDoc("Story Points", 7),
 										columnDoc("Original Time Estimate (in hours)", 8),
 										columnDoc("Time Spent (in hours)", 9)));
-		mongoTemplate.getCollection(KPI_COLUMN_CONFIGS).insertOne(kpiColumnConfigDocument);
+		Document filter = new Document("basicProjectConfigId", null).append(KPI_ID, KPI_205);
+		mongoTemplate
+				.getCollection(KPI_COLUMN_CONFIGS)
+				.replaceOne(filter, kpiColumnConfigDocument, new ReplaceOptions().upsert(true));
 	}
 
 	private Document columnDoc(String name, int order) {

--- a/src/main/java/com/publicissapient/kpidashboard/apis/util/KPIExcelUtility.java
+++ b/src/main/java/com/publicissapient/kpidashboard/apis/util/KPIExcelUtility.java
@@ -2343,10 +2343,41 @@ public class KPIExcelUtility {
 				kpiExcelData.setDate(
 						DateUtil.tranformUTCLocalTimeToZFormat(
 								LocalDateTime.parse(date + DateUtil.ZERO_TIME_FORMAT)));
-				kpiExcelData.setCount(typeCountMap);
+				Map<String, String> countStrMap = new HashMap<>();
+				typeCountMap.forEach((k, v) -> countStrMap.put(k, String.valueOf(v)));
+				kpiExcelData.setCount(countStrMap);
 				excelData.add(kpiExcelData);
 			}
 		}
+	}
+
+	public static void populateFlowKPIWithIds(
+			Map<String, Map<String, List<String>>> dateTypeIdsMap, List<KPIExcelData> excelData) {
+		for (Map.Entry<String, Map<String, List<String>>> entry : dateTypeIdsMap.entrySet()) {
+			String date = entry.getKey();
+			Map<String, List<String>> typeIdsMap = entry.getValue();
+			KPIExcelData kpiExcelData = new KPIExcelData();
+			if (MapUtils.isNotEmpty(typeIdsMap)) {
+				kpiExcelData.setDate(
+						DateUtil.tranformUTCLocalTimeToZFormat(
+								LocalDateTime.parse(date + DateUtil.ZERO_TIME_FORMAT)));
+				Map<String, String> typeFormattedMap = new HashMap<>();
+				typeIdsMap.forEach((type, ids) -> typeFormattedMap.put(type, formatIssueIds(ids)));
+				kpiExcelData.setCount(typeFormattedMap);
+				excelData.add(kpiExcelData);
+			}
+		}
+	}
+
+	private static String formatIssueIds(List<String> ids) {
+		int count = ids.size();
+		if (count == 0) return "0";
+		List<String> displayIds = count > 10 ? ids.subList(0, 10) : ids;
+		String joined = String.join(" | ", displayIds);
+		if (count > 10) {
+			return count + " - " + joined + " | more";
+		}
+		return count + " - " + joined;
 	}
 
 	public static void populateHappinessIndexExcelData(

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -113,6 +113,7 @@ backlogWeekCount=6
 #used in/for :  kpis kpis on dashboard
 flowKpiMonthCount=12
 
+slingshotSprintVelocityMultiGranularity=false
 slingShotFlowKpiMonthCount=3
 #Purpose of properties : property to control whether Flow Distribution (kpi207) includes all historical closures before the display window (true) or starts from 0 (false)
 #used in/for : Flow Distribution Slingshot KPI (kpi207)

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -111,9 +111,9 @@ backlogWeekCount=6
 #Purpose of properties : property used to control number of past month of flow kpis
 #possible values : number [1-15]
 #used in/for :  kpis kpis on dashboard
-flowKpiMonthCount=3
+flowKpiMonthCount=12
 
-slingshotFlowKpiMonthCount=3
+slingShotFlowKpiMonthCount=3
 #Purpose of properties : property used to control the variance threshold for sprint velocity while calculating maturity
 #user in/for : sprint velocity KPI
 sprintVelocityVarianceThreshold = 10

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -114,6 +114,9 @@ backlogWeekCount=6
 flowKpiMonthCount=12
 
 slingShotFlowKpiMonthCount=3
+#Purpose of properties : property to control whether Flow Distribution (kpi207) includes all historical closures before the display window (true) or starts from 0 (false)
+#used in/for : Flow Distribution Slingshot KPI (kpi207)
+flowDistributionIncludeHistoricalData=false
 #Purpose of properties : property used to control the variance threshold for sprint velocity while calculating maturity
 #user in/for : sprint velocity KPI
 sprintVelocityVarianceThreshold = 10

--- a/src/main/resources/json/mongock/default/field_mapping_structure.json
+++ b/src/main/resources/json/mongock/default/field_mapping_structure.json
@@ -3336,6 +3336,174 @@
     "mandatory": true
   },
   {
+    "fieldName": "jiraIssueClosedStateKPI207",
+    "fieldLabel": "Status to identify Close Statuses",
+    "fieldType": "chips",
+    "fieldCategory": "workflow",
+    "processorCommon": false,
+    "section": "WorkFlow Status Mapping",
+    "tooltip": {
+      "definition": "All statuses that signify an issue is 'DONE' based on 'Definition Of Done'"
+    },
+    "mandatory": true
+  },
+  {
+    "fieldName": "jiraIssueTypeKPI202",
+    "fieldLabel": "Issue types to consider",
+    "fieldType": "chips",
+    "fieldCategory": "Issue_Type",
+    "processorCommon": false,
+    "fieldDisplayOrder": 1,
+    "sectionOrder": 2,
+    "section": "Issue Types Mapping",
+    "tooltip": {
+      "definition": "All issue types considered for Cycle calculation"
+    },
+    "mandatory": true,
+    "nodeSpecific": false
+  },
+  {
+    "fieldName": "jiraIssueStatusGroupByCategoryKPI202",
+    "fieldLabel": "Workfow groups",
+    "fieldType": "chips",
+    "fieldCategory": "workflow",
+    "processorCommon": false,
+    "fieldDisplayOrder": 2,
+    "section": "WorkFlow Status Mapping",
+    "tooltip": {
+      "definition": "Workflow status/es that identify that a backlog item is ready to be taken in a sprint based on Definition of Ready (DOR)"
+    },
+    "mandatory": true,
+    "nodeSpecific": false
+  },
+  {
+    "fieldName": "jiraIssueClosedStateKPI203",
+    "fieldLabel": "Status to identify Close Statuses",
+    "fieldType": "chips",
+    "fieldCategory": "workflow",
+    "processorCommon": false,
+    "section": "WorkFlow Status Mapping",
+    "tooltip": {
+      "definition": "All statuses that signify an issue is 'DONE' based on 'Definition Of Done'"
+    },
+    "mandatory": true
+  },
+  {
+    "fieldName": "jiraIssueWaitStateKPI203",
+    "fieldLabel": "Status to identify Wait Statuses",
+    "fieldType": "chips",
+    "fieldCategory": "workflow",
+    "processorCommon": false,
+    "section": "WorkFlow Status Mapping",
+    "tooltip": {
+      "definition": "The statuses wherein no activity takes place and signifies that issue is in queue"
+    },
+    "mandatory": true
+  },
+  {
+    "fieldName": "thresholdValueKPI203",
+    "fieldLabel": "Target KPI Value",
+    "fieldType": "number",
+    "processorCommon": false,
+    "section": "Project Level Threshold",
+    "tooltip": {
+      "definition": "Target KPI value denotes the bare minimum a project should maintain for a KPI. User should just input the number and the unit like percentage, hours will automatically be considered. If the threshold is empty, then a common target KPI line will be shown"
+    }
+  },
+  {
+    "fieldName": "thresholdValueKPI205",
+    "fieldLabel": "Target KPI Value",
+    "fieldType": "number",
+    "processorCommon": false,
+    "fieldDisplayOrder": 1,
+    "sectionOrder": 6,
+    "section": "Project Level Threshold",
+    "tooltip": {
+      "definition": "Target KPI value denotes the bare minimum a project should maintain for a KPI. User should just input the number and the unit like percentage, hours will automatically be considered. If the threshold is empty, then a common target KPI line will be shown"
+    },
+    "mandatory": false
+  },
+  {
+    "fieldName": "jiraIterationCompletionStatusKPI205",
+    "fieldLabel": "Status to identify completed issues",
+    "fieldType": "chips",
+    "fieldCategory": "workflow",
+    "processorCommon": false,
+    "fieldDisplayOrder": 8,
+    "sectionOrder": 4,
+    "section": "WorkFlow Status Mapping",
+    "tooltip": {
+      "definition": "All workflow statuses used to identify completed issues. If multiple statuses are specified, the first status an issue transitions to will be considered."
+    },
+    "mandatory": false
+  },
+  {
+    "fieldName": "jiraIterationIssueTypeKPI205",
+    "fieldLabel": "Issue types filter for completed issues",
+    "fieldType": "chips",
+    "fieldCategory": "Issue_Type",
+    "processorCommon": false,
+    "fieldDisplayOrder": 1,
+    "sectionOrder": 2,
+    "section": "Issue Types Mapping",
+    "tooltip": {
+      "definition": "Completed issues of the specified issue types will be considered. If left blank, all issue types will be included by default."
+    },
+    "mandatory": false
+  },
+  {
+    "fieldName": "jiraIssueTypeNamesKPI206",
+    "fieldLabel": "Issue types to be included",
+    "fieldType": "chips",
+    "fieldCategory": "Issue_Type",
+    "processorCommon": false,
+    "section": "Issue Types Mapping",
+    "tooltip": {
+      "definition": "All issue types used by your Jira project"
+    },
+    "mandatory": true,
+    "nodeSpecific": false
+  },
+  {
+    "fieldName": "storyFirstStatusKPI206",
+    "fieldLabel": "Status to identify issues in refinement",
+    "fieldType": "text",
+    "fieldCategory": "workflow",
+    "processorCommon": false,
+    "section": "WorkFlow Status Mapping",
+    "tooltip": {
+      "definition": "All issue types that identify with a Story."
+    },
+    "mandatory": true,
+    "nodeSpecific": false
+  },
+  {
+    "fieldName": "jiraStatusForInProgressKPI206",
+    "fieldLabel": "Status to identify issues in development",
+    "fieldType": "chips",
+    "fieldCategory": "workflow",
+    "processorCommon": false,
+    "section": "WorkFlow Status Mapping",
+    "tooltip": {
+      "definition": "All statuses that denote incomplete issues but have advanced from their initial creation status."
+    },
+    "mandatory": true,
+    "nodeSpecific": false
+  },
+  {
+    "fieldName": "jiraStatusForQaKPI206",
+    "fieldLabel": "Status to identify issues in testing",
+    "fieldType": "chips",
+    "fieldCategory": "workflow",
+    "processorCommon": false,
+    "section": "WorkFlow Status Mapping",
+    "tooltip": {
+      "definition": "All workflow statuses used to identify issues in testing state"
+    },
+    "mandatory": true,
+    "nodeSpecific": false
+  },
+  {
     "fieldName": "jiraIssueTypeNamesKPI151",
     "fieldLabel": "Issue types to be included",
     "fieldType": "chips",

--- a/src/main/resources/json/mongock/default/kpi_master.json
+++ b/src/main/resources/json/mongock/default/kpi_master.json
@@ -5322,13 +5322,13 @@
   },
   {
     "kpiId": "kpi202",
-    "kpiName": "Cycle Time",
+    "kpiName": "Flow Time",
     "maxValue": "",
     "kpiUnit": "Days",
     "isDeleted": "False",
     "defaultOrder": 1,
     "kpiSource": "Jira",
-    "combinedKpiSource": "Jira/Azure",
+    "combinedKpiSource": "Jira/Azure/Rally",
     "kpiCategory": "Slingshot",
     "groupId": 45,
     "thresholdValue": "",
@@ -5339,10 +5339,9 @@
     "isAdditionalFilterSupport": false,
     "kpiFilter": "dropDown",
     "calculateMaturity": false,
-    "isAggregationStacks": false,
     "aggregationCriteria": "sum",
     "kpiInfo": {
-      "definition": "Cycle time measures the duration of each stage within an issue's complete lifecycle. It is visualized through stacked bar chart by breaking down the time spent in each individual cycle.",
+      "definition": "Elapsed wall-clock time from when work started (entered an active state) to when it reached Done.",
       "details": [
         {
           "type": "link",
@@ -5351,19 +5350,149 @@
             "link": "https://knowhow.tools.publicis.sapient.com/wiki/kpi202-Cycle+Time"
           }
         }
-      ],
-      "formula": null
+      ]
     },
     "isPositiveTrend": false,
     "kpiBaseLine": "0",
-    "showTrend": false
+    "showTrend": false,
+    "kpiWidth": 50
   },
   {
-    "kpiId": "Kpi207",
-    "kpiName": "Flow Distribution Slingshot",
+    "kpiId": "kpi203",
+    "kpiName": "Flow Efficiency",
     "kpiUnit": "",
     "isDeleted": "False",
+    "defaultOrder": 4,
+    "kpiCategory": "Slingshot",
+    "kpiSource": "Jira",
+    "groupId": 45,
+    "thresholdValue": "",
+    "kanban": false,
+    "chartType": "line",
+    "kpiInfo": {
+      "definition": "Ratio of active work time to total flow time. Shows how much of an item's lifetime is spent moving forward versus waiting.",
+      "formula": [
+        {
+          "lhs": "Flow efficiency",
+          "operator": "division",
+          "operands": ["(Active work time)", "(Total lead time) x 100%"]
+        }
+      ]
+    },
+    "xAxisLabel": "Range",
+    "yAxisLabel": "Percentage",
+    "isPositiveTrend": false,
+    "kpiFilter": "dropDown",
+    "showTrend": false,
+    "aggregationCriteria": "average",
+    "isAdditionalFilterSupport": false,
+    "calculateMaturity": false
+  },
+  {
+    "kpiId": "kpi204",
+    "kpiName": "Flow Time Trend",
+    "maxValue": "",
+    "kpiUnit": "Days",
+    "isDeleted": "False",
+    "defaultOrder": 2,
+    "kpiCategory": "Slingshot",
+    "kpiSource": "Jira",
+    "groupId": 34,
+    "thresholdValue": "",
+    "kanban": false,
+    "chartType": "line",
+    "yAxisLabel": "Days",
+    "xAxisLabel": "Range",
+    "isAdditionalFilterSupport": false,
+    "kpiFilter": "dropDown",
+    "calculateMaturity": false,
+    "combinedKpiSource": "Jira/Azure/Rally",
+    "aggregationCriteria": "sum",
+    "kpiInfo": {
+      "definition": "Elapsed wall-clock time from when work started (entered an active state) to when it reached Done.",
+      "details": [
+        {
+          "type": "link",
+          "kpiLinkDetail": {
+            "text": "Detailed Information at",
+            "link": "https://knowhow.tools.publicis.sapient.com/wiki/kpi202-Cycle+Time"
+          }
+        }
+      ]
+    }
+  },
+  {
+    "kpiId": "kpi205",
+    "kpiName": "Flow Velocity",
+    "isDeleted": "False",
+    "defaultOrder": 3,
+    "kpiCategory": "Slingshot",
+    "kpiUnit": "SP",
+    "chartType": "grouped_column_plus_line",
+    "upperThresholdBG": "white",
+    "lowerThresholdBG": "red",
+    "xAxisLabel": "Weeks",
+    "yAxisLabel": "Count",
+    "showTrend": false,
+    "isPositiveTrend": true,
+    "lineLegend": "Sprint Velocity",
+    "barLegend": "Last 5 Sprints Average",
+    "calculateMaturity": true,
+    "hideOverallFilter": false,
+    "kpiSource": "Jira",
+    "maxValue": "300",
+    "thresholdValue": "40",
+    "kanban": false,
+    "groupId": 45,
+    "kpiInfo": {
+      "definition": "Number of flow items completed per unit time, segmented by flow item type. Count of issues where status transitioned to Done within the period, grouped by Flow Item Type custom field."
+    },
+    "kpiFilter": null,
+    "aggregationCriteria": "sum",
+    "isAdditionalFilterSupport": true,
+    "combinedKpiSource": "Jira/Azure/Rally"
+  },
+  {
+    "kpiId": "kpi206",
+    "kpiName": "Flow Load",
+    "isDeleted": "False",
     "defaultOrder": 5,
+    "kpiCategory": "Slingshot",
+    "kpiSubCategory": "Flow KPIs",
+    "kpiUnit": "",
+    "chartType": "stacked-area",
+    "xAxisLabel": "Time",
+    "yAxisLabel": "Count",
+    "showTrend": false,
+    "isPositiveTrend": false,
+    "calculateMaturity": false,
+    "hideOverallFilter": false,
+    "kpiSource": "Jira",
+    "kanban": false,
+    "groupId": 46,
+    "kpiInfo": {
+      "definition": "Number of flow items currently in progress in the value stream (WIP). Too high = thrashing; too low = underutilisation. Count of issues NOT in Backlog/To Do AND NOT in Done at point in time.",
+      "details": [
+        {
+          "type": "link",
+          "kpiLinkDetail": {
+            "text": "Detailed Information at",
+            "link": "https://knowhow.tools.publicis.sapient.com/wiki/kpi148-Flow+Load"
+          }
+        }
+      ]
+    },
+    "kpiFilter": "",
+    "aggregationCriteria": "sum",
+    "isAdditionalFilterSupport": false,
+    "combinedKpiSource": "Jira/Azure/Rally"
+  },
+  {
+    "kpiId": "kpi207",
+    "kpiName": "Flow Distribution",
+    "kpiUnit": "",
+    "isDeleted": "False",
+    "defaultOrder": 6,
     "kpiCategory": "Slingshot",
     "kpiSource": "Jira",
     "combinedKpiSource": "Jira/Azure",
@@ -5372,7 +5501,7 @@
     "kanban": false,
     "chartType": "stacked-area",
     "kpiInfo": {
-      "definition": "Flow Distribution evaluates the amount of each kind of work (issue types) which are open in the backlog over a period of time.",
+      "definition": "Percentage mix of completed work across Features, Defects, Risk, and Tech Debt.",
       "details": [
         {
           "type": "link",

--- a/src/main/resources/json/mongock/default/project_kpi_column_config.json
+++ b/src/main/resources/json/mongock/default/project_kpi_column_config.json
@@ -3735,6 +3735,228 @@
         "isDefault" : true
       }
     ]
+  },
+  {
+    "basicProjectConfigId" : null,
+    "kpiId" : "kpi205",
+    "kpiColumnDetails" : [
+      {
+        "columnName" : "Sprint Name",
+        "order" : 1,
+        "isShown" : true,
+        "isDefault" : true
+      },
+      {
+        "columnName" : "Issue ID",
+        "order" : 2,
+        "isShown" : true,
+        "isDefault" : true
+      },
+      {
+        "columnName" : "Issue Description",
+        "order" : 3,
+        "isShown" : true,
+        "isDefault" : true
+      },
+      {
+        "columnName" : "Squad",
+        "order" : 4,
+        "isShown" : true,
+        "isDefault" : true
+      },
+      {
+        "columnName" : "Issue Type",
+        "order" : 5,
+        "isShown" : true,
+        "isDefault" : true
+      },
+      {
+        "columnName" : "Priority",
+        "order" : 6,
+        "isShown" : true,
+        "isDefault" : true
+      },
+      {
+        "columnName" : "Story Points",
+        "order" : 7,
+        "isShown" : true,
+        "isDefault" : true
+      },
+      {
+        "columnName" : "Original Time Estimate (in hours)",
+        "order" : 8,
+        "isShown" : true,
+        "isDefault" : true
+      },
+      {
+        "columnName" : "Time Spent (in hours)",
+        "order" : 9,
+        "isShown" : true,
+        "isDefault" : true
+      }
+    ]
+  },
+  {
+    "basicProjectConfigId" : null,
+    "kpiId" : "kpi202",
+    "kpiColumnDetails" : [
+      {
+        "columnName" : "Issue ID",
+        "order" : 1,
+        "isShown" : true,
+        "isDefault" : true
+      },
+      {
+        "columnName" : "Issue Type",
+        "order" : 2,
+        "isShown" : true,
+        "isDefault" : true
+      },
+      {
+        "columnName" : "Issue Description",
+        "order" : 3,
+        "isShown" : true,
+        "isDefault" : true
+      },
+      {
+        "columnName" : "Group Map",
+        "order" : 4,
+        "isShown" : true,
+        "isDefault" : true
+      }
+    ]
+  },
+  {
+    "basicProjectConfigId" : null,
+    "kpiId" : "kpi203",
+    "kpiColumnDetails" : [
+      {
+        "columnName" : "Issue ID",
+        "order" : 1,
+        "isShown" : true,
+        "isDefault" : true
+      },
+      {
+        "columnName" : "Issue Type",
+        "order" : 2,
+        "isShown" : true,
+        "isDefault" : true
+      },
+      {
+        "columnName" : "Issue Description",
+        "order" : 3,
+        "isShown" : true,
+        "isDefault" : true
+      },
+      {
+        "columnName" : "Size (In Story Points)",
+        "order" : 4,
+        "isShown" : true,
+        "isDefault" : true
+      },
+      {
+        "columnName" : "Wait Time",
+        "order" : 5,
+        "isShown" : true,
+        "isDefault" : true
+      },
+      {
+        "columnName" : "Total Time",
+        "order" : 6,
+        "isShown" : true,
+        "isDefault" : true
+      },
+      {
+        "columnName" : "Flow Efficiency",
+        "order" : 7,
+        "isShown" : true,
+        "isDefault" : true
+      }
+    ]
+  },
+  {
+    "basicProjectConfigId" : null,
+    "kpiId" : "kpi204",
+    "kpiColumnDetails" : [
+      {
+        "columnName" : "Issue ID",
+        "order" : 1,
+        "isShown" : true,
+        "isDefault" : true
+      },
+      {
+        "columnName" : "Issue Type",
+        "order" : 2,
+        "isShown" : true,
+        "isDefault" : true
+      },
+      {
+        "columnName" : "Issue Description",
+        "order" : 3,
+        "isShown" : true,
+        "isDefault" : true
+      },
+      {
+        "columnName" : "Group Map",
+        "order" : 4,
+        "isShown" : true,
+        "isDefault" : true
+      }
+    ]
+  },
+  {
+    "basicProjectConfigId" : null,
+    "kpiId" : "kpi206",
+    "kpiColumnDetails" : [
+      {
+        "columnName" : "Date",
+        "order" : 0,
+        "isShown" : true,
+        "isDefault" : true
+      },
+      {
+        "columnName" : "In-Analysis",
+        "order" : 1,
+        "isShown" : true,
+        "isDefault" : false
+      },
+      {
+        "columnName" : "In-Testing",
+        "order" : 2,
+        "isShown" : true,
+        "isDefault" : false
+      },
+      {
+        "columnName" : "In-Progress",
+        "order" : 3,
+        "isShown" : true,
+        "isDefault" : false
+      },
+      {
+        "columnName" : "In-Development",
+        "order" : 4,
+        "isShown" : true,
+        "isDefault" : false
+      },
+      {
+        "columnName" : "Open",
+        "order" : 5,
+        "isShown" : true,
+        "isDefault" : false
+      }
+    ]
+  },
+  {
+    "basicProjectConfigId" : null,
+    "kpiId" : "kpi207",
+    "kpiColumnDetails" : [
+      {
+        "columnName" : "Date",
+        "order" : 1,
+        "isShown" : true,
+        "isDefault" : false
+      }
+    ]
   }
 ]
 

--- a/src/test/java/com/publicissapient/kpidashboard/apis/jira/scrum/service/FlowLoadSlingshotServiceImplTest.java
+++ b/src/test/java/com/publicissapient/kpidashboard/apis/jira/scrum/service/FlowLoadSlingshotServiceImplTest.java
@@ -115,7 +115,7 @@ public class FlowLoadSlingshotServiceImplTest {
 
 	@Test
 	public void getKpiData() throws ApplicationException {
-		when(customApiConfig.getSlingShotFlowKpiMonthCount()).thenReturn(12);
+		// when(customApiConfig.getSlingShotFlowKpiMonthCount()).thenReturn(12);
 		String kpiRequestTrackerId = "Jira-Excel-QADD-track001";
 		when(cacheService.getFromApplicationCache(
 						Constant.KPI_REQUEST_TRACKER_ID_KEY + KPISource.JIRA.name()))

--- a/src/test/java/com/publicissapient/kpidashboard/apis/jira/scrum/service/FlowLoadSlingshotServiceImplTest.java
+++ b/src/test/java/com/publicissapient/kpidashboard/apis/jira/scrum/service/FlowLoadSlingshotServiceImplTest.java
@@ -115,7 +115,7 @@ public class FlowLoadSlingshotServiceImplTest {
 
 	@Test
 	public void getKpiData() throws ApplicationException {
-		when(customApiConfig.getFlowKpiMonthCount()).thenReturn(12);
+		when(customApiConfig.getSlingShotFlowKpiMonthCount()).thenReturn(12);
 		String kpiRequestTrackerId = "Jira-Excel-QADD-track001";
 		when(cacheService.getFromApplicationCache(
 						Constant.KPI_REQUEST_TRACKER_ID_KEY + KPISource.JIRA.name()))

--- a/src/test/java/com/publicissapient/kpidashboard/apis/jira/scrum/service/slingshot/FlowDistributionSlingshotServiceImplTest.java
+++ b/src/test/java/com/publicissapient/kpidashboard/apis/jira/scrum/service/slingshot/FlowDistributionSlingshotServiceImplTest.java
@@ -83,7 +83,7 @@ public class FlowDistributionSlingshotServiceImplTest {
 		TreeAggregatorDetail treeAggregatorDetail =
 				KPIHelperUtil.getTreeLeafNodesGroupedByFilter(
 						kpiRequest, accountHierarchyDataList, new ArrayList<>(), "hierarchyLevelOne", 5);
-		when(customApiConfig.getFlowKpiMonthCount()).thenReturn(1);
+		when(customApiConfig.getSlingShotFlowKpiMonthCount()).thenReturn(1);
 		when(configHelperService.getFieldMappingMap()).thenReturn(fieldMappingMap);
 
 		customHistoryList.get(0).setCreatedDate(DateTime.now());

--- a/src/test/java/com/publicissapient/kpidashboard/apis/jira/scrum/service/slingshot/SprintVelocitySlingshotServiceImplTest.java
+++ b/src/test/java/com/publicissapient/kpidashboard/apis/jira/scrum/service/slingshot/SprintVelocitySlingshotServiceImplTest.java
@@ -282,14 +282,14 @@ public class SprintVelocitySlingshotServiceImplTest {
 		issue1.setNumber("ISSUE-1");
 		issue1.setEstimate("5.0");
 		issue1.setStatus("Done");
-		issue1.setChangeDate("2023-11-01 10:00:00");
+		issue1.setChangeDate("2023-11-01T10:00:00");
 		issues.add(issue1);
 
 		JiraIssue issue2 = new JiraIssue();
 		issue2.setNumber("ISSUE-2");
 		issue2.setEstimate("10.0");
 		issue2.setStatus("Closed");
-		issue2.setChangeDate("2023-11-02 10:00:00");
+		issue2.setChangeDate("2023-11-02T10:00:00");
 		issues.add(issue2);
 
 		return issues;
@@ -302,14 +302,14 @@ public class SprintVelocitySlingshotServiceImplTest {
 		issue1.setNumber("ISSUE-1");
 		issue1.setStoryPoints(5.0);
 		issue1.setStatus("Done");
-		issue1.setChangeDate("2023-11-01 10:00:00");
+		issue1.setChangeDate("2023-11-01T10:00:00");
 		issues.add(issue1);
 
 		JiraIssue issue2 = new JiraIssue();
 		issue2.setNumber("ISSUE-2");
 		issue2.setStoryPoints(8.0);
 		issue2.setStatus("Closed");
-		issue2.setChangeDate("2023-11-02 10:00:00");
+		issue2.setChangeDate("2023-11-02T10:00:00");
 		issues.add(issue2);
 
 		return issues;
@@ -322,14 +322,14 @@ public class SprintVelocitySlingshotServiceImplTest {
 		issue1.setNumber("ISSUE-1");
 		issue1.setAggregateTimeOriginalEstimateMinutes(480); // 8 hours
 		issue1.setStatus("Done");
-		issue1.setChangeDate("2023-11-01 10:00:00");
+		issue1.setChangeDate("2023-11-01T10:00:00");
 		issues.add(issue1);
 
 		JiraIssue issue2 = new JiraIssue();
 		issue2.setNumber("ISSUE-2");
 		issue2.setAggregateTimeOriginalEstimateMinutes(240); // 4 hours
 		issue2.setStatus("Closed");
-		issue2.setChangeDate("2023-11-02 10:00:00");
+		issue2.setChangeDate("2023-11-02T10:00:00");
 		issues.add(issue2);
 
 		return issues;


### PR DESCRIPTION
Change log:

- Rounded Flow Velocity KPI aggregate value to 2 decimal places using BigDecimal rounding
- Fixed Flow Velocity list view data ordering — so entries are sorted chronologically (oldest → latest)
- Added missing @Value("${slingShotFlowKpiMonthCount:3}") annotation to slingShotFlowKpiMonthCount field — previously had no binding so the field always returned 0
- Renamed property slingshotFlowKpiMonthCount → slingShotFlowKpiMonthCount to match the @Value key in CustomApiConfig
- Reverted the flowKpiMonthCount to original 12
- Addressing configuration inconsistencies in Mongock deployment scripts.