### PR TITLE
Story Hygiene KPI Enhancements

### DIFF
--- a/src/main/java/com/publicissapient/kpidashboard/apis/jira/scrum/service/slingshot/speed/StoryHygieneKpiSlingshotServiceImpl.java
+++ b/src/main/java/com/publicissapient/kpidashboard/apis/jira/scrum/service/slingshot/speed/StoryHygieneKpiSlingshotServiceImpl.java
@@ -558,7 +558,7 @@ public class StoryHygieneKpiSlingshotServiceImpl
 
 	private DataCount emptyDataCount(String sprintId, String sprintName, String projectName) {
 		DataCount dc = buildDataCount(sprintId, sprintName, projectName, 0.0, new HashMap<>());
-		dc.getHoverValue().put("evaluationFailed", true);
+		dc.getHoverValue().put("Evaluation Status", "Failed");
 		return dc;
 	}
 

--- a/src/main/java/com/publicissapient/kpidashboard/apis/jira/scrum/service/slingshot/speed/StoryHygieneKpiSlingshotServiceImpl.java
+++ b/src/main/java/com/publicissapient/kpidashboard/apis/jira/scrum/service/slingshot/speed/StoryHygieneKpiSlingshotServiceImpl.java
@@ -541,8 +541,8 @@ public class StoryHygieneKpiSlingshotServiceImpl
 		DataCount dataCount =
 				buildDataCount(sprintId, sprintName, projectName, score, passedPercentageByRule);
 
-		dataCount.getHoverValue().put("sampledIssueCount", sampledCount);
-		dataCount.getHoverValue().put("passedIssueCount", passedIssues);
+		dataCount.getHoverValue().put("Sampled Issue Count", sampledCount);
+		dataCount.getHoverValue().put("Passed Issue Count", passedIssues);
 		if (sampledCount < totalIssueCount) {
 			dataCount
 					.getHoverValue()

--- a/src/main/java/com/publicissapient/kpidashboard/apis/jira/scrum/service/slingshot/speed/StoryHygieneKpiSlingshotServiceImpl.java
+++ b/src/main/java/com/publicissapient/kpidashboard/apis/jira/scrum/service/slingshot/speed/StoryHygieneKpiSlingshotServiceImpl.java
@@ -308,6 +308,7 @@ public class StoryHygieneKpiSlingshotServiceImpl
 												new SprintHygieneOutcome(
 														emptyDataCount(sprintId, sprintName, projectName),
 														Collections.emptyList(),
+														0,
 														0));
 									}
 
@@ -336,6 +337,7 @@ public class StoryHygieneKpiSlingshotServiceImpl
 														return new SprintHygieneOutcome(
 																emptyDataCount(sprintId, sprintName, projectName),
 																Collections.emptyList(),
+																0,
 																0);
 													});
 								})
@@ -370,7 +372,8 @@ public class StoryHygieneKpiSlingshotServiceImpl
 		}
 		kpiElement.setExcelColumns(KPIExcelColumn.STORY_HYGIENE.getColumns());
 
-		kpiElement.setScoreFactor(jiraIssuesBySprint.values().stream().mapToInt(List::size).sum());
+		kpiElement.setScoreFactor(
+				outcomes.stream().mapToInt(SprintHygieneOutcome::evaluatedIssueCount).sum());
 		kpiElement.setValidScoreFactor(
 				outcomes.stream().mapToInt(SprintHygieneOutcome::totalPassedIssues).sum());
 
@@ -432,7 +435,7 @@ public class StoryHygieneKpiSlingshotServiceImpl
 					sprintName,
 					sprintId);
 			return new SprintHygieneOutcome(
-					emptyDataCount(sprintId, sprintName, projectName), Collections.emptyList(), 0);
+					emptyDataCount(sprintId, sprintName, projectName), Collections.emptyList(), 0, 0);
 		}
 
 		List<HygieneKpiResponseDTO> issueVerdicts = hygieneKpiParser.parse(responseContent);
@@ -479,7 +482,7 @@ public class StoryHygieneKpiSlingshotServiceImpl
 
 		if (CollectionUtils.isEmpty(issueVerdicts)) {
 			return new SprintHygieneOutcome(
-					emptyDataCount(sprintId, sprintName, projectName), List.of(), 0);
+					emptyDataCount(sprintId, sprintName, projectName), List.of(), 0, 0);
 		}
 
 		List<HygieneKpiResponseDTO.RuleResult> allRuleResults =
@@ -550,11 +553,13 @@ public class StoryHygieneKpiSlingshotServiceImpl
 		KPIExcelUtility.populateStoryHygieneExcelData(
 				excelRows, sprintName != null ? sprintName : sprintId, issueVerdicts);
 
-		return new SprintHygieneOutcome(dataCount, excelRows, passedIssues);
+		return new SprintHygieneOutcome(dataCount, excelRows, passedIssues, (int) totalIssues);
 	}
 
 	private DataCount emptyDataCount(String sprintId, String sprintName, String projectName) {
-		return buildDataCount(sprintId, sprintName, projectName, 0.0, new HashMap<>());
+		DataCount dc = buildDataCount(sprintId, sprintName, projectName, 0.0, new HashMap<>());
+		dc.getHoverValue().put("evaluationFailed", true);
+		return dc;
 	}
 
 	private DataCount buildDataCount(
@@ -579,7 +584,13 @@ public class StoryHygieneKpiSlingshotServiceImpl
 		return dataCount;
 	}
 
-	/** Bundle returned by the per-sprint pipeline — trend point + excel rows + passed count. */
+	/**
+	 * Bundle returned by the per-sprint pipeline — trend point + excel rows + passed/evaluated
+	 * counts.
+	 */
 	private record SprintHygieneOutcome(
-			DataCount dataCount, List<KPIExcelData> excelRows, int totalPassedIssues) {}
+			DataCount dataCount,
+			List<KPIExcelData> excelRows,
+			int totalPassedIssues,
+			int evaluatedIssueCount) {}
 }

--- a/src/main/java/com/publicissapient/kpidashboard/apis/jira/scrum/service/slingshot/speed/StoryHygieneKpiSlingshotServiceImpl.java
+++ b/src/main/java/com/publicissapient/kpidashboard/apis/jira/scrum/service/slingshot/speed/StoryHygieneKpiSlingshotServiceImpl.java
@@ -16,7 +16,6 @@ import java.util.OptionalDouble;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
-import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.stream.Collectors;
 
 import org.apache.commons.collections4.CollectionUtils;
@@ -73,346 +72,6 @@ public class StoryHygieneKpiSlingshotServiceImpl
 
 	private static final String JIRA_ISSUES = "jiraIssues";
 	private static final String SPRINT_DETAILS = "sprintDetails";
-
-	/**
-	 * Fallback response used when the AI Gateway is unavailable. Shown to the user but never
-	 * persisted.
-	 */
-	static final String MOCK_HYGIENE_RESPONSE_JSON =
-			"""
-			[
-				{
-					"issueKey": "DTS-48971",
-					"issueType": "Story",
-					"sprintId": "55076_a4fbe170-8667-4878-a877-a1b1300d8b16",
-					"assignee": "Raja Kurru",
-					"results": [
-						{
-							"rule": "Assignee Set",
-							"field": "assigneeName",
-							"observed": "Raja Kurru",
-							"status": "Passed",
-							"reason": "assigneeName is populated with a valid team member name"
-						},
-						{
-							"rule": "Story Points Estimated",
-							"field": "estimate",
-							"observed": "3.0",
-							"status": "Passed",
-							"reason": "estimate is set to 3.0, greater than 0"
-						},
-						{
-							"rule": "Priority Set",
-							"field": "priority",
-							"observed": "P3 - Major",
-							"status": "Passed",
-							"reason": "priority is set to P3 - Major, a recognised priority value"
-						},
-						{
-							"rule": "Sprint Assigned",
-							"field": "sprintID",
-							"observed": "55076_a4fbe170-8667-4878-a877-a1b1300d8b16",
-							"status": "Passed",
-							"reason": "sprintID is populated, issue is tagged to KnowHOW | PI_23| ITR_6"
-						},
-						{
-							"rule": "Issue Type Valid",
-							"field": "typeName",
-							"observed": "Story",
-							"status": "Passed",
-							"reason": "typeName is Story, a recognised issue type"
-						},
-						{
-							"rule": "Summary Meaningful",
-							"field": "summary",
-							"observed": "FE | Role based access to KH Resources | Move access control from FE to BE",
-							"status": "Passed",
-							"reason": "summary clearly describes the feature scope and the architectural direction of the change"
-						},
-						{
-							"rule": "Acceptance Criteria Defined",
-							"field": "description",
-							"observed": "Given a user with role X / When they navigate to KH Resources / Then access is enforced by BE role rules and the FE reflects the result accordingly",
-							"status": "Passed",
-							"reason": "description contains structured Given-When-Then AC with testable role-based outcomes"
-						}
-					],
-					"totalApplicableRules": 7,
-					"passedRules": 7,
-					"failedRules": 0,
-					"partialRules": 0,
-					"hygieneScore": 100,
-					"hygieneGrade": "GOOD",
-					"overallStatus": "READY",
-					"topFailures": [],
-					"recommendations": "Story is well-defined | Add edge-case AC for users with multiple conflicting roles | Document expected API contract between FE and BE | Add negative scenario for unauthorized access attempt | Consider adding rollback plan for the access migration"
-				},
-				{
-					"issueKey": "DTS-47979",
-					"issueType": "Story",
-					"sprintId": "55076_a4fbe170-8667-4878-a877-a1b1300d8b16",
-					"assignee": "Andrada Mihai",
-					"results": [
-						{
-							"rule": "Assignee Set",
-							"field": "assigneeName",
-							"observed": "Andrada Mihai",
-							"status": "Passed",
-							"reason": "assigneeName is populated with a valid team member name"
-						},
-						{
-							"rule": "Story Points Estimated",
-							"field": "estimate",
-							"observed": "3.0",
-							"status": "Passed",
-							"reason": "estimate is set to 3.0, greater than 0"
-						},
-						{
-							"rule": "Priority Set",
-							"field": "priority",
-							"observed": "P3 - Major",
-							"status": "Passed",
-							"reason": "priority is set to P3 - Major, a recognised priority value"
-						},
-						{
-							"rule": "Sprint Assigned",
-							"field": "sprintID",
-							"observed": "55076_a4fbe170-8667-4878-a877-a1b1300d8b16",
-							"status": "Passed",
-							"reason": "sprintID is populated, issue is tagged to KnowHOW | PI_23| ITR_6"
-						},
-						{
-							"rule": "Issue Type Valid",
-							"field": "typeName",
-							"observed": "Story",
-							"status": "Passed",
-							"reason": "typeName is Story, a recognised issue type"
-						},
-						{
-							"rule": "Summary Meaningful",
-							"field": "summary",
-							"observed": "FE | Enhance Retro UI for supporting soft delete/pause",
-							"status": "Passed",
-							"reason": "summary clearly identifies the UI component and the feature being enhanced"
-						},
-						{
-							"rule": "Acceptance Criteria Defined",
-							"field": "description",
-							"observed": "UI should support soft delete and pause. States should be reflected in the list view.",
-							"status": "Partial",
-							"reason": "description outlines expected behaviour but lacks structured format, does not define visual treatment of soft-deleted items, and omits undo/restore scenarios"
-						}
-					],
-					"totalApplicableRules": 7,
-					"passedRules": 6,
-					"failedRules": 0,
-					"partialRules": 1,
-					"hygieneScore": 85,
-					"hygieneGrade": "GOOD",
-					"overallStatus": "NOT READY",
-					"topFailures": ["Acceptance Criteria Defined"],
-					"recommendations": "Rewrite AC in Given-When-Then or checklist format | Add scenario for restoring a soft-deleted item | Define visual treatment of paused vs deleted state | Specify keyboard and screen-reader behaviour for state toggles | Link to Figma designs if available"
-				},
-				{
-					"issueKey": "DTS-50876",
-					"issueType": "Story",
-					"sprintId": "55076_a4fbe170-8667-4878-a877-a1b1300d8b16",
-					"assignee": "Theodor Constantin",
-					"results": [
-						{
-							"rule": "Assignee Set",
-							"field": "assigneeName",
-							"observed": "Theodor Constantin",
-							"status": "Passed",
-							"reason": "assigneeName is populated with a valid team member name"
-						},
-						{
-							"rule": "Story Points Estimated",
-							"field": "estimate",
-							"observed": "5.0",
-							"status": "Passed",
-							"reason": "estimate is set to 5.0, greater than 0"
-						},
-						{
-							"rule": "Priority Set",
-							"field": "priority",
-							"observed": "P3 - Major",
-							"status": "Passed",
-							"reason": "priority is set to P3 - Major, a recognised priority value"
-						},
-						{
-							"rule": "Sprint Assigned",
-							"field": "sprintID",
-							"observed": "55076_a4fbe170-8667-4878-a877-a1b1300d8b16",
-							"status": "Passed",
-							"reason": "sprintID is populated, issue is tagged to KnowHOW | PI_23| ITR_6"
-						},
-						{
-							"rule": "Issue Type Valid",
-							"field": "typeName",
-							"observed": "Story",
-							"status": "Passed",
-							"reason": "typeName is Story, a recognised issue type"
-						},
-						{
-							"rule": "Summary Meaningful",
-							"field": "summary",
-							"observed": "BE | Developer KPIs - As a user, I want the system to predict the next KPI value for Quality KPIs so that I can anticipate performance trends and plan corrective actions.",
-							"status": "Passed",
-							"reason": "summary follows user-story format and clearly states the user goal, context, and benefit"
-						},
-						{
-							"rule": "Acceptance Criteria Defined",
-							"field": "description",
-							"observed": "System should predict next sprint KPI value using historical data. Prediction should be visible on the KPI tile.",
-							"status": "Partial",
-							"reason": "description states the high-level expectation but does not define the prediction algorithm, confidence threshold, fallback when history is insufficient, or how the predicted value is visually differentiated from actual"
-						}
-					],
-					"totalApplicableRules": 7,
-					"passedRules": 6,
-					"failedRules": 0,
-					"partialRules": 1,
-					"hygieneScore": 85,
-					"hygieneGrade": "GOOD",
-					"overallStatus": "NOT READY",
-					"topFailures": ["Acceptance Criteria Defined"],
-					"recommendations": "Define minimum sprint history required before prediction activates | Specify visual treatment of predicted vs actual value on the KPI tile | Add AC for fallback when insufficient data is available | Clarify which Quality KPIs are in scope for this iteration | Add non-functional requirement for prediction latency"
-				},
-				{
-					"issueKey": "DTS-50715",
-					"issueType": "Bug",
-					"sprintId": "55076_a4fbe170-8667-4878-a877-a1b1300d8b16",
-					"assignee": "Baldev Krishna",
-					"results": [
-						{
-							"rule": "Assignee Set",
-							"field": "assigneeName",
-							"observed": "Baldev Krishna",
-							"status": "Passed",
-							"reason": "assigneeName is populated with a valid team member name"
-						},
-						{
-							"rule": "Story Points Estimated",
-							"field": "estimate",
-							"observed": "0",
-							"status": "Failed",
-							"reason": "estimate is 0; bug has not been sized by the team"
-						},
-						{
-							"rule": "Priority Set",
-							"field": "priority",
-							"observed": "P3 - Major",
-							"status": "Passed",
-							"reason": "priority is set to P3 - Major, a recognised priority value"
-						},
-						{
-							"rule": "Sprint Assigned",
-							"field": "sprintID",
-							"observed": "55076_a4fbe170-8667-4878-a877-a1b1300d8b16",
-							"status": "Passed",
-							"reason": "sprintID is populated, issue is tagged to KnowHOW | PI_23| ITR_6"
-						},
-						{
-							"rule": "Issue Type Valid",
-							"field": "typeName",
-							"observed": "Bug",
-							"status": "Passed",
-							"reason": "typeName is Bug, a recognised issue type"
-						},
-						{
-							"rule": "Summary Meaningful",
-							"field": "summary",
-							"observed": "Regression issue - Jira Configuration Type & Template dropdown showing empty values instead of expected configuration options",
-							"status": "Passed",
-							"reason": "summary clearly describes the regression symptom and the affected UI component"
-						},
-						{
-							"rule": "Acceptance Criteria Defined",
-							"field": "description",
-							"observed": "null",
-							"status": "Failed",
-							"reason": "description field is empty; no reproduction steps, expected behaviour, or fix-verification criteria documented"
-						}
-					],
-					"totalApplicableRules": 7,
-					"passedRules": 5,
-					"failedRules": 2,
-					"partialRules": 0,
-					"hygieneScore": 71,
-					"hygieneGrade": "AVERAGE",
-					"overallStatus": "NOT READY",
-					"topFailures": ["Story Points Estimated", "Acceptance Criteria Defined"],
-					"recommendations": "Add story point estimate to size the fix effort | Document reproduction steps: steps to reproduce, expected vs actual behaviour | Specify affected Jira configuration types and templates | Attach screenshot showing the empty dropdown | Link to related regression test case"
-				},
-				{
-					"issueKey": "DTS-51662",
-					"issueType": "Story",
-					"sprintId": "55076_a4fbe170-8667-4878-a877-a1b1300d8b16",
-					"assignee": "Akshat Shrivastav",
-					"results": [
-						{
-							"rule": "Assignee Set",
-							"field": "assigneeName",
-							"observed": "Akshat Shrivastav",
-							"status": "Passed",
-							"reason": "assigneeName is populated with a valid team member name"
-						},
-						{
-							"rule": "Story Points Estimated",
-							"field": "estimate",
-							"observed": "0",
-							"status": "Failed",
-							"reason": "estimate is 0; story has not been sized by the team"
-						},
-						{
-							"rule": "Priority Set",
-							"field": "priority",
-							"observed": "P3 - Major",
-							"status": "Passed",
-							"reason": "priority is set to P3 - Major, a recognised priority value"
-						},
-						{
-							"rule": "Sprint Assigned",
-							"field": "sprintID",
-							"observed": "55076_a4fbe170-8667-4878-a877-a1b1300d8b16",
-							"status": "Passed",
-							"reason": "sprintID is populated, issue is tagged to KnowHOW | PI_23| ITR_6"
-						},
-						{
-							"rule": "Issue Type Valid",
-							"field": "typeName",
-							"observed": "Story",
-							"status": "Passed",
-							"reason": "typeName is Story, a recognised issue type"
-						},
-						{
-							"rule": "Summary Meaningful",
-							"field": "summary",
-							"observed": "L3 Rollout Support ITR6",
-							"status": "Failed",
-							"reason": "summary is 4 words relying on unexplained acronyms (L3, ITR6); it functions as a label rather than a description of user value or scope"
-						},
-						{
-							"rule": "Acceptance Criteria Defined",
-							"field": "description",
-							"observed": "null",
-							"status": "Failed",
-							"reason": "description field is empty; no acceptance criteria, scope, or deliverables documented"
-						}
-					],
-					"totalApplicableRules": 7,
-					"passedRules": 4,
-					"failedRules": 3,
-					"partialRules": 0,
-					"hygieneScore": 57,
-					"hygieneGrade": "AVERAGE",
-					"overallStatus": "NOT READY",
-					"topFailures": ["Story Points Estimated", "Summary Meaningful", "Acceptance Criteria Defined"],
-					"recommendations": "Replace summary with a meaningful description of the rollout scope and user value | Add story point estimate | Document acceptance criteria: what constitutes a successful L3 rollout for ITR6 | List affected modules and environments | Define exit criteria for rollout completion"
-				}
-			]
-			""";
 
 	@Autowired private HygieneKpiParser hygieneKpiParser;
 	@Autowired private JiraIssueRepository jiraIssueRepository;
@@ -576,7 +235,6 @@ public class StoryHygieneKpiSlingshotServiceImpl
 						.filter(ji -> ji.getSprintID() != null)
 						.collect(Collectors.groupingBy(JiraIssue::getSprintID));
 
-		AtomicBoolean mockServed = new AtomicBoolean(false);
 		List<CompletableFuture<SprintHygieneOutcome>> futures =
 				sprintDetailsList.stream()
 						.filter(sd -> !jiraIssuesBySprint.getOrDefault(sd.getSprintID(), List.of()).isEmpty())
@@ -669,18 +327,9 @@ public class StoryHygieneKpiSlingshotServiceImpl
 													hygieneAiExecutor)
 											.exceptionally(
 													ex -> {
-														Throwable cause = ex.getCause() != null ? ex.getCause() : ex;
-														if (cause instanceof MockHygieneResponseException mockEx) {
-															if (mockServed.compareAndSet(false, true)) {
-																return mockEx.outcome();
-															}
-															return new SprintHygieneOutcome(
-																	emptyDataCount(sprintId, sprintName, projectName),
-																	Collections.emptyList(),
-																	0);
-														}
 														log.error(
-																"Hygiene evaluation failed for sprint {}: {}",
+																"Hygiene evaluation failed for sprint '{}'({}): {}",
+																sprintName,
 																sprintId,
 																ex.getMessage(),
 																ex);
@@ -769,7 +418,7 @@ public class StoryHygieneKpiSlingshotServiceImpl
 			log.debug("kpi311 [{}]: content={}", sprintName, responseContent);
 		} catch (Exception ex) {
 			log.error(
-					"AI Gateway call failed for sprint '{}' ({}): {} — returning mock data (not persisted)",
+					"AI Gateway call failed for sprint '{}' ({}): {}",
 					sprintName,
 					sprintId,
 					ex.getMessage(),
@@ -779,18 +428,11 @@ public class StoryHygieneKpiSlingshotServiceImpl
 
 		if (responseContent == null || responseContent.isBlank()) {
 			log.warn(
-					"AI Gateway returned blank content for sprint '{}' ({}) — returning mock data (not persisted)",
+					"AI Gateway returned blank content for sprint '{}' ({}) — skipping sprint (not persisted)",
 					sprintName,
 					sprintId);
-			List<HygieneKpiResponseDTO> mockVerdicts = hygieneKpiParser.parse(MOCK_HYGIENE_RESPONSE_JSON);
-			// Mock verdicts don't have real URLs — enrich from the live issueUrlMap so
-			// hyperlinks still work if mock issue keys happen to match real ones.
-			mockVerdicts.forEach(v -> v.setIssueUrl(issueUrlMap.getOrDefault(v.getIssueKey(), "")));
-			// Throw so the exceptionally handler returns an outcome built from mock — no DB
-			// write
-			throw new MockHygieneResponseException(
-					buildOutcomeFromVerdicts(
-							sprintId, sprintName, projectName, mockVerdicts, sampledCount, totalIssueCount));
+			return new SprintHygieneOutcome(
+					emptyDataCount(sprintId, sprintName, projectName), Collections.emptyList(), 0);
 		}
 
 		List<HygieneKpiResponseDTO> issueVerdicts = hygieneKpiParser.parse(responseContent);
@@ -940,22 +582,4 @@ public class StoryHygieneKpiSlingshotServiceImpl
 	/** Bundle returned by the per-sprint pipeline — trend point + excel rows + passed count. */
 	private record SprintHygieneOutcome(
 			DataCount dataCount, List<KPIExcelData> excelRows, int totalPassedIssues) {}
-
-	/**
-	 * Thrown by {@link #computeSprintHygiene} when the AI Gateway is unavailable and the mock
-	 * response is used. Carries the pre-built outcome so the {@code exceptionally} handler can return
-	 * it — bypassing the DB persist while still showing data to the user.
-	 */
-	private static final class MockHygieneResponseException extends RuntimeException {
-		private final SprintHygieneOutcome outcome;
-
-		MockHygieneResponseException(SprintHygieneOutcome outcome) {
-			super("AI Gateway unavailable — serving mock hygiene data");
-			this.outcome = outcome;
-		}
-
-		SprintHygieneOutcome outcome() {
-			return outcome;
-		}
-	}
 }

--- a/src/test/java/com/publicissapient/kpidashboard/apis/jira/scrum/service/slingshot/speed/StoryHygieneKpiSlingshotServiceImplTest.java
+++ b/src/test/java/com/publicissapient/kpidashboard/apis/jira/scrum/service/slingshot/speed/StoryHygieneKpiSlingshotServiceImplTest.java
@@ -277,6 +277,12 @@ public class StoryHygieneKpiSlingshotServiceImplTest {
 		return g;
 	}
 
+	private CycleTimeGroup groupWithWeight(String label, String prompt, Integer weightage) {
+		CycleTimeGroup g = group(label, prompt);
+		g.setWeightage(weightage);
+		return g;
+	}
+
 	private FieldMapping fieldMappingWith(List<CycleTimeGroup> groups) {
 		FieldMapping fm = new FieldMapping();
 		fm.setJiraFieldsSelectionKPI311(groups);
@@ -700,32 +706,29 @@ public class StoryHygieneKpiSlingshotServiceImplTest {
 	}
 
 	@Test
-	public void testWeightPrefix_isParsedAndStrippedFromCriteria() throws ApplicationException {
+	public void testWeightage_fromField_isRenderedAsWeight() throws ApplicationException {
 		String rules =
 				captureRulesFor(
 						Collections.singletonList(
-								group("description", "[10]: Acceptance criteria must be present")));
+								groupWithWeight("description", "Acceptance criteria must be present", 10)));
 
 		assertTrue(rules.contains("weight: 10"));
 		assertTrue(rules.contains("criteria: Acceptance criteria must be present"));
-		// The bracket prefix must never leak through to the LLM.
-		assertFalse(rules.contains("[10]"));
 	}
 
 	@Test
-	public void testNullWeight_fallsBackToDefaultWeightOfOne() throws ApplicationException {
+	public void testNullWeightage_fallsBackToDefaultWeightOfOne() throws ApplicationException {
 		String rules =
 				captureRulesFor(
-						Collections.singletonList(group("priority", "[null]: Priority must be set")));
+						Collections.singletonList(groupWithWeight("priority", "Priority must be set", null)));
 
 		assertTrue(rules.contains("weight: 1"));
 		assertTrue(rules.contains("criteria: Priority must be set"));
-		assertFalse(rules.contains("[null]"));
 	}
 
 	@Test
-	public void testMissingWeightPrefix_fallsBackToDefaultWeightOfOne() throws ApplicationException {
-		// Rule sets authored before weighting existed carry no prefix at all.
+	public void testUnsetWeightage_fallsBackToDefaultWeightOfOne() throws ApplicationException {
+		// weightage not set on the group (null by default) → weight 1.
 		String rules =
 				captureRulesFor(Collections.singletonList(group("priority", "Priority must be set")));
 
@@ -734,14 +737,12 @@ public class StoryHygieneKpiSlingshotServiceImplTest {
 	}
 
 	@Test
-	public void testMixedWeights_eachRuleKeepsItsOwnWeight() throws ApplicationException {
-		// Two rule sets on the same field with different weights — each must survive
-		// as an independent, individually-weighted rule.
+	public void testMixedWeightages_eachRuleKeepsItsOwnWeight() throws ApplicationException {
 		String rules =
 				captureRulesFor(
 						Arrays.asList(
-								group("description", "[10]: Acceptance criteria must be present"),
-								group("description", "[null]: A BDD definition must be present")));
+								groupWithWeight("description", "Acceptance criteria must be present", 10),
+								groupWithWeight("description", "A BDD definition must be present", null)));
 
 		assertTrue(rules.contains("ruleName: description (1)"));
 		assertTrue(rules.contains("ruleName: description (2)"));
@@ -751,22 +752,22 @@ public class StoryHygieneKpiSlingshotServiceImplTest {
 	}
 
 	@Test
-	public void testDecimalWeight_isPreserved() throws ApplicationException {
+	public void testLargeWeightage_isRenderedCorrectly() throws ApplicationException {
 		String rules =
 				captureRulesFor(
-						Collections.singletonList(group("priority", "[2.5]: Priority must be set")));
+						Collections.singletonList(groupWithWeight("priority", "Priority must be set", 50)));
 
-		assertTrue(rules.contains("weight: 2.5"));
+		assertTrue(rules.contains("weight: 50"));
 	}
 
 	@Test
-	public void testMalformedWeight_fallsBackToDefaultAndKeepsCriteria() throws ApplicationException {
-		// Non-numeric and non-positive weights must not break rule rendering.
+	public void testZeroAndNullWeightage_fallBackToDefault() throws ApplicationException {
+		// Zero and null are both invalid — both must fall back to weight 1.
 		String rules =
 				captureRulesFor(
 						Arrays.asList(
-								group("priority", "[abc]: Priority must be set"),
-								group("summary", "[0]: Summary must be meaningful")));
+								groupWithWeight("priority", "Priority must be set", null),
+								groupWithWeight("summary", "Summary must be meaningful", 0)));
 
 		assertEquals(2, countOccurrences(rules, "weight: 1"));
 		assertTrue(rules.contains("criteria: Priority must be set"));
@@ -774,24 +775,24 @@ public class StoryHygieneKpiSlingshotServiceImplTest {
 	}
 
 	@Test
-	public void testWeightPrefixWithIrregularSpacing_isStillParsed() throws ApplicationException {
+	public void testNegativeWeightage_fallsBackToDefault() throws ApplicationException {
 		String rules =
-				captureRulesFor(Collections.singletonList(group("priority", "  [ 7 ] :   Priority set  ")));
+				captureRulesFor(
+						Collections.singletonList(groupWithWeight("priority", "Priority must be set", -5)));
 
-		assertTrue(rules.contains("weight: 7"));
-		assertTrue(rules.contains("criteria: Priority set"));
+		assertTrue(rules.contains("weight: 1"));
 	}
 
 	@Test
-	public void testCriteriaContainingBrackets_isNotMistakenForAWeight() throws ApplicationException {
-		// Only a LEADING [x]: prefix is a weight — brackets inside the text are safe.
+	public void testCriteriaText_isPassedThroughAsIs() throws ApplicationException {
+		// Criteria text (including brackets) is handed to the LLM verbatim.
 		String rules =
 				captureRulesFor(
 						Collections.singletonList(
 								group("description", "Must reference [JIRA-123] in the body")));
 
-		assertTrue(rules.contains("weight: 1"));
 		assertTrue(rules.contains("criteria: Must reference [JIRA-123] in the body"));
+		assertTrue(rules.contains("weight: 1"));
 	}
 
 	@Test
@@ -822,32 +823,51 @@ public class StoryHygieneKpiSlingshotServiceImplTest {
 		verify(aiGatewayClient, times(1)).generate(any(ChatGenerationRequest.class));
 	}
 
-	// @Test
-	// public void testGetKpiData_aiGatewayThrows_fallbackToEmptyDataCount()
-	// throws ApplicationException {
-	// mockFieldMapping(fieldMappingWith(Collections.singletonList(group("Rule1",
-	// "Prompt1"))));
-	// SprintDetails sd = createSprintDetails("SP1", "Sprint 1",
-	// "2026-01-01T00:00:00Z");
-	// when(sprintDetailsService.getSprintDetailsByIds(any()))
-	// .thenReturn(Collections.singletonList(sd));
-	// when(jiraIssueRepository.findBySprintIDInAndBasicProjectConfigId(anySet(),
-	// anyString()))
-	// .thenReturn(Collections.singletonList(createJiraIssue("ISS-1", "SP1")));
-	// when(aiGatewayClient.generate(any(ChatGenerationRequest.class)))
-	// .thenThrow(new RuntimeException("boom"));
-	//
-	// KpiElement result =
-	// service.getKpiData(
-	// kpiRequest,
-	// kpiElement,
-	// buildTree(Collections.singletonList(createSprintLeafNode("SP1", "Sprint
-	// 1"))));
-	//
-	// assertNotNull(result);
-	// // Parser must never have been consulted because AI threw before parsing.
-	// verify(hygieneKpiParser, never()).parse(anyString());
-	// }
+	@Test
+	public void testGetKpiData_aiGatewayThrows_fallbackToEmptyDataCount()
+			throws ApplicationException {
+		mockFieldMapping(fieldMappingWith(Collections.singletonList(group("Rule1", "Prompt1"))));
+		SprintDetails sd = createSprintDetails("SP1", "Sprint 1", "2026-01-01T00:00:00Z");
+		when(sprintDetailsService.getSprintDetailsByIds(any()))
+				.thenReturn(Collections.singletonList(sd));
+		when(jiraIssueRepository.findBySprintIDInAndBasicProjectConfigIdWithFields(
+						anySet(), anyString(), anySet()))
+				.thenReturn(Collections.singletonList(createJiraIssue("ISS-1", "SP1")));
+		when(aiGatewayClient.generate(any(ChatGenerationRequest.class)))
+				.thenThrow(new RuntimeException("boom"));
+
+		KpiElement result =
+				service.getKpiData(
+						kpiRequest,
+						kpiElement,
+						buildTree(Collections.singletonList(createSprintLeafNode("SP1", "Sprint 1"))));
+
+		assertNotNull(result);
+		verify(hygieneKpiParser, never()).parse(anyString());
+	}
+
+	@Test
+	public void testGetKpiData_aiGatewayReturnsBlank_fallsBackToEmptyOutcome()
+			throws ApplicationException {
+		mockFieldMapping(fieldMappingWith(Collections.singletonList(group("Rule1", "Prompt1"))));
+		SprintDetails sd = createSprintDetails("SP1", "Sprint 1", "2026-01-01T00:00:00Z");
+		when(sprintDetailsService.getSprintDetailsByIds(any()))
+				.thenReturn(Collections.singletonList(sd));
+		when(jiraIssueRepository.findBySprintIDInAndBasicProjectConfigIdWithFields(
+						anySet(), anyString(), anySet()))
+				.thenReturn(Collections.singletonList(createJiraIssue("ISS-1", "SP1")));
+		when(aiGatewayClient.generate(any(ChatGenerationRequest.class)))
+				.thenReturn(new ChatGenerationResponseDTO(""));
+
+		KpiElement result =
+				service.getKpiData(
+						kpiRequest,
+						kpiElement,
+						buildTree(Collections.singletonList(createSprintLeafNode("SP1", "Sprint 1"))));
+
+		assertNotNull(result);
+		verify(hygieneKpiParser, never()).parse(anyString());
+	}
 
 	@Test
 	public void testGetKpiData_parserThrows_fallbackToEmptyDataCount() throws ApplicationException {


### PR DESCRIPTION
Changelog:
Remove hardcoded mock hygiene response; AI Gateway failures now return an empty outcome gracefully 
Read rule weight from CycleTimeGroup.weightage instead of parsing [weight]: prefix from prompt text