### PR TITLE
Defect Fix: Resolve all hierarchy nodes by name in kpiIntegrationValues

### DIFF
--- a/src/main/java/com/publicissapient/kpidashboard/apis/kpiintegration/service/KpiIntegrationServiceImpl.java
+++ b/src/main/java/com/publicissapient/kpidashboard/apis/kpiintegration/service/KpiIntegrationServiceImpl.java
@@ -24,6 +24,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
@@ -324,13 +325,15 @@ public class KpiIntegrationServiceImpl {
 		}
 		String[] hierarchyIdList;
 		if (kpiRequest.getHierarchyName() != null) {
-			OrganizationHierarchy byNodeNameAndHierarchyLevelId =
-					organizationHierarchyRepository.findByNodeNameAndHierarchyLevelId(
+			List<OrganizationHierarchy> matches =
+					organizationHierarchyRepository.findAllByNodeNameAndHierarchyLevelId(
 							kpiRequest.getHierarchyName(), hierarchyLevel.getHierarchyLevelId());
-			if (byNodeNameAndHierarchyLevelId != null
-					&& byNodeNameAndHierarchyLevelId.getNodeId() != null) {
-				String nodeId = byNodeNameAndHierarchyLevelId.getNodeId();
-				hierarchyIdList = new String[] {nodeId};
+			if (CollectionUtils.isNotEmpty(matches)) {
+				hierarchyIdList =
+						matches.stream()
+								.map(OrganizationHierarchy::getNodeId)
+								.filter(Objects::nonNull)
+								.toArray(String[]::new);
 			} else {
 				throw new IllegalArgumentException("No hierarchy data found for given name/level");
 			}

--- a/src/test/java/com/publicissapient/kpidashboard/apis/kpiintegration/service/KpiIntegrationServiceImplTest.java
+++ b/src/test/java/com/publicissapient/kpidashboard/apis/kpiintegration/service/KpiIntegrationServiceImplTest.java
@@ -125,9 +125,9 @@ public class KpiIntegrationServiceImplTest {
 		OrganizationHierarchy organizationHierarchy = new OrganizationHierarchy();
 		organizationHierarchy.setNodeId("123");
 		organizationHierarchy.setNodeName("DTS");
-		when(organizationHierarchyRepository.findByNodeNameAndHierarchyLevelId(
+		when(organizationHierarchyRepository.findAllByNodeNameAndHierarchyLevelId(
 						anyString(), anyString()))
-				.thenReturn(organizationHierarchy);
+				.thenReturn(List.of(organizationHierarchy));
 	}
 
 	@Test


### PR DESCRIPTION
Changelog:
findByNodeNameAndHierarchyLevelId returned a single result, causing a 500 error when multiple nodes share the same name (e.g. "Methods and Tools" across different accounts). Changed to findAllByNodeNameAndHierarchyLevelId so all matching nodeIds are resolved automatically, removing the need for callers to pass internal IDs.