### PR TITLE
Add config flags to control hierarchy sync operations

### DIFF
--- a/src/main/java/com/publicissapient/kpidashboard/apis/config/CustomApiConfig.java
+++ b/src/main/java/com/publicissapient/kpidashboard/apis/config/CustomApiConfig.java
@@ -267,6 +267,9 @@ public class CustomApiConfig { // NOPMD
 	private String rnrRecommendationUrl;
 	private String centralHierarchyUrl;
 	private String centralHierarchyApiKey;
+	private boolean hierarchySyncAllowInserts = false;
+	private boolean hierarchySyncAllowUpdates = false;
+	private boolean hierarchySyncPauseProjects = false;
 
 	public String getRnrRecommendationUrl() {
 		return rnrRecommendationUrl;

--- a/src/main/java/com/publicissapient/kpidashboard/apis/hierarchy/integration/controller/IntegrateHierarchyScheduler.java
+++ b/src/main/java/com/publicissapient/kpidashboard/apis/hierarchy/integration/controller/IntegrateHierarchyScheduler.java
@@ -56,35 +56,37 @@ public class IntegrateHierarchyScheduler {
 
 	@Scheduled(cron = "${hierarchySync.cron}")
 	public void callApi() {
+		try {
+			executeSync();
+		} catch (Exception e) {
+			log.error("Hierarchy sync failed. Error: {}", e.getMessage());
+		}
+	}
+
+	public void executeSync() {
 		String apiUrl = customApiConfig.getCentralHierarchyUrl();
 
 		HttpHeaders headers = new HttpHeaders();
-		// add x-api-key
 		headers.add("x-api-key", customApiConfig.getCentralHierarchyApiKey());
-
 		headers.setContentType(MediaType.APPLICATION_JSON);
 		HttpEntity<String> requestEntity = new HttpEntity<>(headers);
 
 		ReaderRetryHelper.RetryableOperation<ResponseEntity<String>> retryableOperation =
 				() -> restTemplate.exchange(apiUrl, HttpMethod.GET, requestEntity, String.class);
 
-		try {
-			ResponseEntity<String> response = retryHelper.executeWithRetry(retryableOperation);
-			if (response.getStatusCode().is2xxSuccessful()) {
-				HierarchyDetailParser hierarchyDetailParser = new SF360Parser();
-				HierarchyDetails hierarchyDetails =
-						hierarchyDetailParser.convertToHierachyDetail(response.getBody());
-				// Step 1: Fetch all existing records from the database
-				List<OrganizationHierarchy> allDbNodes = organizationHierarchyRepository.findAll();
-				Set<OrganizationHierarchy> centralHierarchies =
-						integerationService.convertHieracyResponseToOrganizationHierachy(
-								hierarchyDetails, allDbNodes);
-				integerationService.syncOrganizationHierarchy(centralHierarchies, allDbNodes);
-			} else {
-				throw new HttpServerErrorException(response.getStatusCode(), "API call failed");
-			}
-		} catch (Exception e) {
-			log.error("API call failed after retries. Error: {}", e.getMessage());
+		ResponseEntity<String> response = retryHelper.executeWithRetry(retryableOperation);
+		if (response.getStatusCode().is2xxSuccessful()) {
+			HierarchyDetailParser hierarchyDetailParser = new SF360Parser();
+			HierarchyDetails hierarchyDetails =
+					hierarchyDetailParser.convertToHierachyDetail(response.getBody());
+			List<OrganizationHierarchy> allDbNodes = organizationHierarchyRepository.findAll();
+			Set<OrganizationHierarchy> centralHierarchies =
+					integerationService.convertHieracyResponseToOrganizationHierachy(
+							hierarchyDetails, allDbNodes);
+			integerationService.syncOrganizationHierarchy(centralHierarchies, allDbNodes);
+		} else {
+			throw new HttpServerErrorException(
+					response.getStatusCode(), "Central hierarchy API call failed");
 		}
 	}
 }

--- a/src/main/java/com/publicissapient/kpidashboard/apis/hierarchy/integration/service/IntegrationServiceImpl.java
+++ b/src/main/java/com/publicissapient/kpidashboard/apis/hierarchy/integration/service/IntegrationServiceImpl.java
@@ -28,6 +28,7 @@ import java.util.stream.Collectors;
 import org.apache.commons.collections4.CollectionUtils;
 import org.springframework.stereotype.Service;
 
+import com.publicissapient.kpidashboard.apis.config.CustomApiConfig;
 import com.publicissapient.kpidashboard.apis.hierarchy.integration.adapter.OrganizationHierarchyAdapter;
 import com.publicissapient.kpidashboard.apis.hierarchy.integration.dto.HierarchyDetails;
 import com.publicissapient.kpidashboard.apis.hierarchy.service.OrganizationHierarchyService;
@@ -55,13 +56,18 @@ public class IntegrationServiceImpl implements IntegerationService {
 	private final OrganizationHierarchyAdapter organizationHierarchyAdapter;
 	private final ProjectBasicConfigRepository projectConfigRepository;
 	private final OrganizationHierarchyService organizationHierarchyService;
+	private final CustomApiConfig customApiConfig;
 
 	@Override
 	public void syncOrganizationHierarchy(
 			Set<OrganizationHierarchy> externalList, List<OrganizationHierarchy> allDbNodes) {
 
 		// Step 1: Pause projects and ports with missing parent external IDs
-		pauseProjectsWithUnavailablePortExternalID(externalList, allDbNodes);
+		if (customApiConfig.isHierarchySyncPauseProjects()) {
+			pauseProjectsWithUnavailablePortExternalID(externalList, allDbNodes);
+		} else {
+			log.info("Hierarchy sync: project pausing is disabled (hierarchySync.pauseProjects=false)");
+		}
 
 		// Step 2: Map database records by externalId for quick lookup
 		Map<String, OrganizationHierarchy> databaseMapByExternalId =
@@ -88,27 +94,35 @@ public class IntegrationServiceImpl implements IntegerationService {
 			OrganizationHierarchy dbNode = databaseMapByExternalId.get(externalNode.getExternalId());
 
 			if (dbNode == null) {
-				// New node: set createdDate and modifiedDate, and add to save list
-				externalNode.setCreatedDate(LocalDateTime.now());
-				externalNode.setModifiedDate(LocalDateTime.now());
-				nodesToSave.add(externalNode);
+				if (customApiConfig.isHierarchySyncAllowInserts()) {
+					externalNode.setCreatedDate(LocalDateTime.now());
+					externalNode.setModifiedDate(LocalDateTime.now());
+					nodesToSave.add(externalNode);
+				} else {
+					log.debug(
+							"Hierarchy sync: insert skipped for externalId={} (hierarchySync.allowInserts=false)",
+							externalNode.getExternalId());
+				}
 			} else {
-				// Existing node: update fields and add to save list
-				dbNode.setNodeName(externalNode.getNodeName());
-				dbNode.setNodeDisplayName(externalNode.getNodeName());
-				dbNode.setHierarchyLevelId(externalNode.getHierarchyLevelId());
-				dbNode.setParentId(externalNode.getParentId());
-				dbNode.setModifiedDate(LocalDateTime.now());
-				nodesToSave.add(dbNode);
+				if (customApiConfig.isHierarchySyncAllowUpdates()) {
+					dbNode.setNodeName(externalNode.getNodeName());
+					dbNode.setNodeDisplayName(externalNode.getNodeName());
+					dbNode.setHierarchyLevelId(externalNode.getHierarchyLevelId());
+					dbNode.setParentId(externalNode.getParentId());
+					dbNode.setModifiedDate(LocalDateTime.now());
+					nodesToSave.add(dbNode);
+				} else {
+					log.debug(
+							"Hierarchy sync: update skipped for externalId={} (hierarchySync.allowUpdates=false)",
+							externalNode.getExternalId());
+				}
 			}
 		}
 
 		// Save all new and updated nodes and update the maps
 		if (CollectionUtils.isNotEmpty(nodesToSave)) {
-			// Save all nodes
 			organizationHierarchyService.saveAll(nodesToSave);
 
-			// Update our maps with the nodes that were just saved
 			for (OrganizationHierarchy node : nodesToSave) {
 				if (node.getExternalId() != null) {
 					databaseMapByExternalId.put(node.getExternalId(), node);

--- a/src/main/java/com/publicissapient/kpidashboard/apis/hierarchy/rest/OrganizationHierarchyController.java
+++ b/src/main/java/com/publicissapient/kpidashboard/apis/hierarchy/rest/OrganizationHierarchyController.java
@@ -32,6 +32,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 import com.publicissapient.kpidashboard.apis.hierarchy.dto.CreateHierarchyRequest;
 import com.publicissapient.kpidashboard.apis.hierarchy.dto.UpdateHierarchyRequest;
+import com.publicissapient.kpidashboard.apis.hierarchy.integration.controller.IntegrateHierarchyScheduler;
 import com.publicissapient.kpidashboard.apis.hierarchy.service.HierarchyOptionService;
 import com.publicissapient.kpidashboard.apis.hierarchy.service.OrganizationHierarchyService;
 import com.publicissapient.kpidashboard.apis.model.ServiceResponse;
@@ -44,10 +45,12 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
 @RestController
 @RequestMapping("/hierarchy")
 @RequiredArgsConstructor
+@Slf4j
 @Tag(
 		name = "Organization Hierarchy API",
 		description = "APIs for Organization Hierarchy Management")
@@ -56,6 +59,8 @@ public class OrganizationHierarchyController {
 	private final OrganizationHierarchyService organizationHierarchyService;
 
 	private final HierarchyOptionService hierarchyOptionService;
+
+	private final IntegrateHierarchyScheduler integrateHierarchyScheduler;
 
 	@Operation(
 			summary = "Get Organization Hierarchies",
@@ -126,5 +131,29 @@ public class OrganizationHierarchyController {
 					@RequestBody
 					UpdateHierarchyRequest request) {
 		return organizationHierarchyService.updateName(request.getDisplayName(), id);
+	}
+
+	@Operation(
+			summary = "Trigger Central Hierarchy Sync",
+			description =
+					"Manually triggers the central hierarchy sync job. Respects the same operation flags "
+							+ "(hierarchySync.allowInserts, hierarchySync.allowUpdates, hierarchySync.pauseProjects) "
+							+ "as the scheduled run.")
+	@ApiResponses(
+			value = {
+				@ApiResponse(responseCode = "200", description = "Hierarchy sync triggered successfully"),
+				@ApiResponse(responseCode = "500", description = "Hierarchy sync failed")
+			})
+	@PostMapping("/sync")
+	public ResponseEntity<ServiceResponse> triggerHierarchySync() {
+		try {
+			integrateHierarchyScheduler.executeSync();
+			return ResponseEntity.status(HttpStatus.OK)
+					.body(new ServiceResponse(true, "Hierarchy sync completed successfully.", null));
+		} catch (Exception e) {
+			log.error("Hierarchy sync trigger failed: {}", e.getMessage());
+			return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+					.body(new ServiceResponse(false, "Hierarchy sync failed: " + e.getMessage(), null));
+		}
 	}
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -569,6 +569,10 @@ project.efficiency.weightage=SPEED=25,QUALITY=25,VALUE=25,DORA=25
 #cron to sync with central hierarchy
 #Replace cron value to  0 0 23 ? * MON to run every week once
 hierarchySync.cron=0 0 23 1 5 ?
+#Control which operations the hierarchy sync performs
+hierarchySync.allowInserts=false
+hierarchySync.allowUpdates=false
+hierarchySync.pauseProjects=false
 
 #Each mapping corresponds to the header at same position in required-headers
 ai-usage-file-format.required-headers.mappings=Email Address,PROMPT COUNT,BU Name,Industry,Client Name

--- a/src/test/java/com/publicissapient/kpidashboard/apis/hierarchy/integeration/service/IntegrationServiceImplTest.java
+++ b/src/test/java/com/publicissapient/kpidashboard/apis/hierarchy/integeration/service/IntegrationServiceImplTest.java
@@ -45,6 +45,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 
+import com.publicissapient.kpidashboard.apis.config.CustomApiConfig;
 import com.publicissapient.kpidashboard.apis.hierarchy.integration.adapter.OrganizationHierarchyAdapter;
 import com.publicissapient.kpidashboard.apis.hierarchy.integration.dto.HierarchyDetails;
 import com.publicissapient.kpidashboard.apis.hierarchy.integration.dto.HierarchyLevel;
@@ -64,6 +65,8 @@ public class IntegrationServiceImplTest {
 
 	@Mock private OrganizationHierarchyService organizationHierarchyService;
 
+	@Mock private CustomApiConfig customApiConfig;
+
 	@InjectMocks private IntegrationServiceImpl integrationService;
 
 	private List<OrganizationHierarchy> allDbNodes;
@@ -75,6 +78,11 @@ public class IntegrationServiceImplTest {
 		allDbNodes = createTestDbNodes();
 		externalList = createTestExternalNodes();
 		hierarchyDetails = createTestHierarchyDetails();
+
+		// Default config: only inserts enabled, updates and project pausing disabled
+		when(customApiConfig.isHierarchySyncAllowInserts()).thenReturn(true);
+		when(customApiConfig.isHierarchySyncAllowUpdates()).thenReturn(false);
+		when(customApiConfig.isHierarchySyncPauseProjects()).thenReturn(false);
 	}
 
 	// Test Data Factory Methods
@@ -212,7 +220,9 @@ public class IntegrationServiceImplTest {
 
 	@Test
 	public void testSyncOrganizationHierarchy_HappyPath() {
-		// Arrange
+		// Arrange: EXT_PORT_001 already exists in DB — this exercises the update path
+		when(customApiConfig.isHierarchySyncAllowUpdates()).thenReturn(true);
+
 		Set<OrganizationHierarchy> externalNodes = new HashSet<>();
 		OrganizationHierarchy updatedNode = new OrganizationHierarchy();
 		updatedNode.setId(new ObjectId("507f1f77bcf86cd799439017"));
@@ -228,13 +238,6 @@ public class IntegrationServiceImplTest {
 
 		doNothing().when(organizationHierarchyService).saveAll(anyList());
 		doNothing().when(organizationHierarchyService).clearCache();
-
-		List<ProjectBasicConfig> projectConfigs = createTestProjectConfigs();
-		/*
-		 * when(projectConfigRepository.findByProjectNodeIdIn(anySet())).thenReturn(
-		 * projectConfigs);
-		 * when(projectConfigRepository.saveAll(anyList())).thenReturn(projectConfigs);
-		 */
 
 		// Act
 		integrationService.syncOrganizationHierarchy(externalNodes, allDbNodes);
@@ -263,10 +266,6 @@ public class IntegrationServiceImplTest {
 		doNothing().when(organizationHierarchyService).saveAll(anyList());
 		doNothing().when(organizationHierarchyService).clearCache();
 
-		List<ProjectBasicConfig> projectConfigs = createTestProjectConfigs();
-		when(projectConfigRepository.findByProjectNodeIdIn(anySet())).thenReturn(projectConfigs);
-		when(projectConfigRepository.saveAll(anyList())).thenReturn(projectConfigs);
-
 		// Act
 		integrationService.syncOrganizationHierarchy(externalNodes, allDbNodes);
 
@@ -274,6 +273,7 @@ public class IntegrationServiceImplTest {
 		ArgumentCaptor<List<OrganizationHierarchy>> saveCaptor = ArgumentCaptor.forClass(List.class);
 		verify(organizationHierarchyService, times(1)).saveAll(saveCaptor.capture());
 		verify(organizationHierarchyService, times(1)).clearCache();
+		verify(projectConfigRepository, never()).findByProjectNodeIdIn(anySet());
 
 		List<OrganizationHierarchy> savedNodes = saveCaptor.getValue();
 		assertEquals(1, savedNodes.size());
@@ -494,16 +494,105 @@ public class IntegrationServiceImplTest {
 		// Arrange
 		Set<OrganizationHierarchy> emptyExternalNodes = new HashSet<>();
 
-		List<ProjectBasicConfig> projectConfigs = createTestProjectConfigs();
-		when(projectConfigRepository.findByProjectNodeIdIn(anySet())).thenReturn(projectConfigs);
-		when(projectConfigRepository.saveAll(anyList())).thenReturn(projectConfigs);
-
 		// Act
 		integrationService.syncOrganizationHierarchy(emptyExternalNodes, allDbNodes);
 
 		// Assert
 		verify(organizationHierarchyService, never()).saveAll(anyList());
 		verify(organizationHierarchyService, never()).clearCache();
+		verify(projectConfigRepository, never()).findByProjectNodeIdIn(anySet());
+	}
+
+	// Config flag tests
+
+	@Test
+	public void testSyncOrganizationHierarchy_InsertsDisabled_NewNodeNotSaved() {
+		when(customApiConfig.isHierarchySyncAllowInserts()).thenReturn(false);
+
+		Set<OrganizationHierarchy> externalNodes = new HashSet<>();
+		OrganizationHierarchy newNode = new OrganizationHierarchy();
+		newNode.setExternalId("EXT_BRAND_NEW");
+		newNode.setNodeId("new_001");
+		newNode.setNodeName("Brand New Node");
+		newNode.setHierarchyLevelId("port");
+		externalNodes.add(newNode);
+
+		integrationService.syncOrganizationHierarchy(externalNodes, allDbNodes);
+
+		verify(organizationHierarchyService, never()).saveAll(anyList());
+		verify(organizationHierarchyService, never()).clearCache();
+	}
+
+	@Test
+	public void testSyncOrganizationHierarchy_UpdatesEnabled_ExistingNodeUpdated() {
+		when(customApiConfig.isHierarchySyncAllowUpdates()).thenReturn(true);
+
+		// EXT_PORT_001 already exists in DB
+		Set<OrganizationHierarchy> externalNodes = new HashSet<>();
+		OrganizationHierarchy updatedNode = new OrganizationHierarchy();
+		updatedNode.setExternalId("EXT_PORT_001");
+		updatedNode.setNodeId("port_001");
+		updatedNode.setNodeName("Renamed Port");
+		updatedNode.setHierarchyLevelId("port");
+		updatedNode.setParentId("root_001");
+		externalNodes.add(updatedNode);
+
+		doNothing().when(organizationHierarchyService).saveAll(anyList());
+		doNothing().when(organizationHierarchyService).clearCache();
+
+		integrationService.syncOrganizationHierarchy(externalNodes, allDbNodes);
+
+		ArgumentCaptor<List<OrganizationHierarchy>> saveCaptor = ArgumentCaptor.forClass(List.class);
+		verify(organizationHierarchyService, times(1)).saveAll(saveCaptor.capture());
+		assertEquals("Renamed Port", saveCaptor.getValue().get(0).getNodeName());
+	}
+
+	@Test
+	public void testSyncOrganizationHierarchy_UpdatesDisabled_ExistingNodeNotSaved() {
+		// allowUpdates=false is the default set in setUp()
+
+		// EXT_PORT_001 already exists in DB
+		Set<OrganizationHierarchy> externalNodes = new HashSet<>();
+		OrganizationHierarchy updatedNode = new OrganizationHierarchy();
+		updatedNode.setExternalId("EXT_PORT_001");
+		updatedNode.setNodeId("port_001");
+		updatedNode.setNodeName("Renamed Port");
+		updatedNode.setHierarchyLevelId("port");
+		updatedNode.setParentId("root_001");
+		externalNodes.add(updatedNode);
+
+		integrationService.syncOrganizationHierarchy(externalNodes, allDbNodes);
+
+		verify(organizationHierarchyService, never()).saveAll(anyList());
+		verify(organizationHierarchyService, never()).clearCache();
+	}
+
+	@Test
+	public void testSyncOrganizationHierarchy_PauseProjectsEnabled_ProjectPaused() {
+		when(customApiConfig.isHierarchySyncPauseProjects()).thenReturn(true);
+
+		// External list does NOT contain EXT_PORT_001, so project_001 (child of port_001) should be
+		// paused
+		Set<OrganizationHierarchy> externalNodes = new HashSet<>();
+
+		List<ProjectBasicConfig> projectConfigs = createTestProjectConfigs();
+		when(projectConfigRepository.findByProjectNodeIdIn(anySet())).thenReturn(projectConfigs);
+		when(projectConfigRepository.saveAll(anyList())).thenReturn(projectConfigs);
+
+		integrationService.syncOrganizationHierarchy(externalNodes, allDbNodes);
+
 		verify(projectConfigRepository, times(1)).findByProjectNodeIdIn(anySet());
+		verify(projectConfigRepository, times(1)).saveAll(anyList());
+	}
+
+	@Test
+	public void testSyncOrganizationHierarchy_PauseProjectsDisabled_ProjectNotPaused() {
+		// pauseProjects=false is the default set in setUp()
+		Set<OrganizationHierarchy> externalNodes = new HashSet<>();
+
+		integrationService.syncOrganizationHierarchy(externalNodes, allDbNodes);
+
+		verify(projectConfigRepository, never()).findByProjectNodeIdIn(anySet());
+		verify(projectConfigRepository, never()).saveAll(anyList());
 	}
 }


### PR DESCRIPTION
Changelog:
Introduces three application.properties flags — hierarchySync.allowInserts, hierarchySync.allowUpdates, and hierarchySync.pauseProjects — to independently enable/disable each operation performed by the central hierarchy sync scheduler.